### PR TITLE
chore: prettier-format new-component-checklist

### DIFF
--- a/docs/new-component-checklist.md
+++ b/docs/new-component-checklist.md
@@ -137,11 +137,11 @@ After all files are in place:
 | Component       | `packages/components/src/{name}/{name}.tsx`, `index.ts` |
 | Manifest        | `packages/components/src/{name}/manifest.json`          |
 | Docs            | `packages/components/src/{name}/{name}.md`              |
-| Global CSS      | `apps/docs/src/index.css` (demo)                  |
+| Global CSS      | `apps/docs/src/index.css` (demo)                        |
 | Intents         | `packages/intelligence/intents.json`                    |
 | MCP data        | `packages/mcp-server/src/data.ts`                       |
 | MCP tsconfig    | `packages/mcp-server/tsconfig.json`                     |
 | Barrel          | `packages/components/src/index.ts`                      |
 | Package exports | `packages/components/package.json`                      |
 | Build entry     | `packages/components/tsup.config.ts`                    |
-| Docs demo       | `apps/docs/src/App.tsx`                           |
+| Docs demo       | `apps/docs/src/App.tsx`                                 |


### PR DESCRIPTION
## Summary
- CI `pnpm format:check` broke on main after the prior PR because my rename edits to `docs/new-component-checklist.md` left it unformatted.
- This is a formatting-only fix (table column alignment) — no content changes.

## Test plan
- [x] `pnpm format:check` passes locally