### PR TITLE
feat: set primary color to Sodium Orange

### DIFF
--- a/packages/styles/src/themes.stylex.ts
+++ b/packages/styles/src/themes.stylex.ts
@@ -8,10 +8,10 @@ import { tokens } from '@basex-ui/tokens';
 export const lightTheme = stylex.createTheme(tokens, {
   // Light theme matches the defaults in tokens.stylex.ts.
   // Explicitly listed here for clarity and as the canonical reference.
-  colorPrimary: 'oklch(0.55 0.2 250)',
-  colorPrimaryHover: 'oklch(0.50 0.22 250)',
-  colorPrimaryActive: 'oklch(0.45 0.24 250)',
-  colorPrimaryContrast: 'oklch(0.98 0 0)',
+  colorPrimary: 'oklch(0.703 0.198 43.4)',
+  colorPrimaryHover: 'oklch(0.738 0.171 46.0)',
+  colorPrimaryActive: 'oklch(0.454 0.123 44.0)',
+  colorPrimaryContrast: 'oklch(0.145 0.002 286)',
 
   colorSecondary: 'oklch(0.55 0.05 260)',
   colorSecondaryHover: 'oklch(0.50 0.06 260)',
@@ -107,11 +107,11 @@ export const lightTheme = stylex.createTheme(tokens, {
  * Surfaces are dark, text is light, colors shift for contrast on dark backgrounds.
  */
 export const darkTheme = stylex.createTheme(tokens, {
-  // Primary — lighter on dark backgrounds
-  colorPrimary: 'oklch(0.70 0.18 250)',
-  colorPrimaryHover: 'oklch(0.75 0.20 250)',
-  colorPrimaryActive: 'oklch(0.65 0.16 250)',
-  colorPrimaryContrast: 'oklch(0.15 0 0)',
+  // Primary — Sodium Orange on dark backgrounds
+  colorPrimary: 'oklch(0.703 0.198 43.4)',
+  colorPrimaryHover: 'oklch(0.738 0.171 46.0)',
+  colorPrimaryActive: 'oklch(0.454 0.123 44.0)',
+  colorPrimaryContrast: 'oklch(0.145 0.002 286)',
 
   // Secondary — lighter on dark backgrounds
   colorSecondary: 'oklch(0.70 0.04 260)',

--- a/packages/tokens/src/tokens.stylex.ts
+++ b/packages/tokens/src/tokens.stylex.ts
@@ -9,11 +9,11 @@ import * as stylex from '@stylexjs/stylex';
 export const tokens = stylex.defineVars({
   // --- Colors (OKLCH-based, semantic aliases) ---
 
-  // Primary palette
-  colorPrimary: 'oklch(0.55 0.2 250)',
-  colorPrimaryHover: 'oklch(0.50 0.22 250)',
-  colorPrimaryActive: 'oklch(0.45 0.24 250)',
-  colorPrimaryContrast: 'oklch(0.98 0 0)',
+  // Primary palette — Sodium Orange (#FF6B1A)
+  colorPrimary: 'oklch(0.703 0.198 43.4)',
+  colorPrimaryHover: 'oklch(0.738 0.171 46.0)',
+  colorPrimaryActive: 'oklch(0.454 0.123 44.0)',
+  colorPrimaryContrast: 'oklch(0.145 0.002 286)',
 
   // Secondary palette
   colorSecondary: 'oklch(0.55 0.05 260)',


### PR DESCRIPTION
## What changed

Updated the `colorPrimary` slot across the BaseX-UI design system to the "Sodium Orange" accent sourced from the Runnar project.

- `packages/tokens/src/tokens.stylex.ts` — base primary palette (light defaults)
- `packages/styles/src/themes.stylex.ts` — explicit `lightTheme` + `darkTheme` overrides

All four existing slots were mapped from Runnar's accent system; no new tokens were invented.

| Slot                 | Source (Runnar) | Hex      | OKLCH                         |
| -------------------- | --------------- | -------- | ----------------------------- |
| `colorPrimary`       | `accent`        | #FF6B1A  | `oklch(0.703 0.198 43.4)`     |
| `colorPrimaryHover`  | `accentHover`   | #FF8240  | `oklch(0.738 0.171 46.0)`     |
| `colorPrimaryActive` | `accentDim`     | #8C3A0E  | `oklch(0.454 0.123 44.0)`     |
| `colorPrimaryContrast` | `accentFg`    | #0A0A0B  | `oklch(0.145 0.002 286)`      |

Propagation is automatic — every consumer references `tokens.colorPrimary*` via StyleX, so no component files were touched.

## Decisions made

- **Hex → OKLCH.** The project rule forbids hex/rgb in tokens, so each Runnar value was converted to OKLCH (L/C/H from the existing `hexToOklch` utility).
- **Slot mapping.** Runnar's `accentDim` maps to `colorPrimaryActive` because that slot is used for the pressed/darker state (its original L=0.45 matches the existing convention of darker-active). No "dim" slot exists in the BaseX system; none was invented.
- **Dark theme.** Previously used a lighter-than-base primary on dark backgrounds (L=0.70) with lighter hover. Kept the same orange values on both themes — Sodium Orange at L=0.703 already reads well on dark surfaces, and the lighter `accentHover` (L=0.738) preserves the "hover goes lighter on dark" convention.
- **Contrast/foreground.** Used Runnar's `accentFg` (#0A0A0B) for both themes — orange is light enough in both contexts that a dark foreground gives the correct AA contrast, consistent with Runnar's own usage.
- **Minimal diff.** Only the four primary color declarations changed in each block. Secondary, destructive, muted, surface, text, focus, spacing, typography, radius, shadow, and motion tokens are untouched.

## What needs review

- Visual regression across components that heavily use primary (button primary variant, radio, checkbox, progress, meter, focus rings that reference primary, combobox selected state). A Vercel preview should light up the full docs site.
- Confirm the pressed/active state (#8C3A0E) reads as a deliberate darkening rather than a mud tone at component scale.
- Confirm the #0A0A0B foreground on the orange surface reads cleanly for button labels on both themes.

## Vercel preview

Flagging — no Vercel preview URL yet. Vercel auto-deploys from `apps/docs/dist` on PR; URL will populate in the checks tab once CI completes. Will update here when it does.

## Test plan

- [ ] `pnpm build` — passes locally
- [ ] `pnpm test:ci` — 50/50 tests pass locally
- [ ] `pnpm lint` — no new warnings/errors
- [ ] `pnpm format:check` — clean
- [ ] Vercel preview: visually verify primary color across Button, Radio, Checkbox, Progress, Meter, Combobox, focus rings
- [ ] Dark theme: verify contrast on primary-filled surfaces