### PR TITLE
feat: add Separator component

### DIFF
--- a/apps/docs/src/content/api-docs.ts
+++ b/apps/docs/src/content/api-docs.ts
@@ -22,6 +22,7 @@ import popover from '../../../../packages/components/src/popover/popover.md?raw'
 import previewCard from '../../../../packages/components/src/preview-card/preview-card.md?raw';
 import progress from '../../../../packages/components/src/progress/progress.md?raw';
 import radio from '../../../../packages/components/src/radio/radio.md?raw';
+import separator from '../../../../packages/components/src/separator/separator.md?raw';
 
 export const apiDocs: Record<string, string> = {
   accordion,
@@ -48,4 +49,5 @@ export const apiDocs: Record<string, string> = {
   'preview-card': previewCard,
   progress,
   radio,
+  separator,
 };

--- a/apps/docs/src/pages/SeparatorPage.tsx
+++ b/apps/docs/src/pages/SeparatorPage.tsx
@@ -1,0 +1,88 @@
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { Separator } from '@basex-ui/components';
+import { Preview } from '../components/Preview';
+
+const styles = stylex.create({
+  stack: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.space3,
+    width: '100%',
+  },
+  stackItem: {
+    fontFamily: tokens.fontFamilySans,
+    fontSize: tokens.fontSizeSm,
+    color: tokens.colorText,
+  },
+  inlineRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.space3,
+    height: '24px',
+    fontFamily: tokens.fontFamilySans,
+    fontSize: tokens.fontSizeSm,
+    color: tokens.colorText,
+  },
+  metaLabel: {
+    color: tokens.colorTextMuted,
+  },
+});
+
+export function SeparatorPage() {
+  return (
+    <>
+      <Preview
+        title="Horizontal"
+        description="The default. Spans the full width of its container with a 1px line."
+        code={`<Separator.Root />`}
+      >
+        <div {...stylex.props(styles.stack)}>
+          <div {...stylex.props(styles.stackItem)}>Account settings</div>
+          <Separator.Root />
+          <div {...stylex.props(styles.stackItem)}>Notifications</div>
+          <Separator.Root />
+          <div {...stylex.props(styles.stackItem)}>Billing</div>
+        </div>
+      </Preview>
+
+      <Preview
+        title="Vertical"
+        description="Inside a flex row, a vertical separator splits inline metadata or toolbar groups."
+        code={`<div style={{ display: 'flex', alignItems: 'center', gap: 12, height: 24 }}>
+  <span>Jane Doe</span>
+  <Separator.Root orientation="vertical" />
+  <span>5 min read</span>
+  <Separator.Root orientation="vertical" />
+  <span>Apr 25, 2026</span>
+</div>`}
+      >
+        <div {...stylex.props(styles.inlineRow)}>
+          <span>Jane Doe</span>
+          <Separator.Root orientation="vertical" />
+          <span {...stylex.props(styles.metaLabel)}>5 min read</span>
+          <Separator.Root orientation="vertical" />
+          <span {...stylex.props(styles.metaLabel)}>Apr 25, 2026</span>
+        </div>
+      </Preview>
+
+      <Preview
+        title="Decorative vs. semantic"
+        description='By default, Separator exposes role="separator" to assistive tech. Pass `decorative` when the divider is purely visual and adjacent content is already grouped semantically — screen readers will skip it (role="none").'
+        code={`{/* Semantic — announced as a separator */}
+<Separator.Root />
+
+{/* Decorative — skipped by screen readers */}
+<Separator.Root decorative />`}
+      >
+        <div {...stylex.props(styles.stack)}>
+          <div {...stylex.props(styles.stackItem)}>Semantic separator</div>
+          <Separator.Root />
+          <div {...stylex.props(styles.stackItem)}>Decorative separator</div>
+          <Separator.Root decorative />
+          <div {...stylex.props(styles.stackItem)}>Both look identical</div>
+        </div>
+      </Preview>
+    </>
+  );
+}

--- a/apps/docs/src/registry.ts
+++ b/apps/docs/src/registry.ts
@@ -24,6 +24,7 @@ import { PopoverPage } from './pages/PopoverPage';
 import { PreviewCardPage } from './pages/PreviewCardPage';
 import { ProgressPage } from './pages/ProgressPage';
 import { RadioPage } from './pages/RadioPage';
+import { SeparatorPage } from './pages/SeparatorPage';
 
 export interface PageEntry {
   id: string;
@@ -262,6 +263,14 @@ export const pages: PageEntry[] = [
     path: '/components/radio',
     section: 'components',
     component: RadioPage,
+  },
+  {
+    id: 'separator',
+    label: 'Separator',
+    description: 'A thin visual divider between content groups.',
+    path: '/components/separator',
+    section: 'components',
+    component: SeparatorPage,
   },
 
   // Intelligence section

--- a/docs/plans/component-roadmap.md
+++ b/docs/plans/component-roadmap.md
@@ -35,7 +35,7 @@
 | 25  | Radio           | `Radio`          | Done     |              |
 | 26  | Scroll Area     | `ScrollArea`     | **Next** |              |
 | 27  | Select          | `Select`         | —        |              |
-| 28  | Separator       | `Separator`      | —        |              |
+| 28  | Separator       | `Separator`      | Done     |              |
 | 29  | Slider          | `Slider`         | —        |              |
 | 30  | Switch          | `Switch`         | —        |              |
 | 31  | Tabs            | `Tabs`           | —        |              |
@@ -47,7 +47,7 @@
 
 ## Progress
 
-- **Done**: 25 / 36
+- **Done**: 26 / 36
 - **Next**: Scroll Area
 
 ## How to Use This File

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -120,6 +120,10 @@
     "./radio": {
       "types": "./dist/radio/index.d.ts",
       "import": "./dist/radio/index.js"
+    },
+    "./separator": {
+      "types": "./dist/separator/index.d.ts",
+      "import": "./dist/separator/index.js"
     }
   },
   "files": [

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -220,3 +220,6 @@ export type {
   RadioRootProps,
   RadioIndicatorProps,
 } from './radio';
+
+export { Separator } from './separator';
+export type { SeparatorRootProps } from './separator';

--- a/packages/components/src/separator/index.ts
+++ b/packages/components/src/separator/index.ts
@@ -1,0 +1,2 @@
+export { Separator } from './separator';
+export type { SeparatorRootProps } from './separator';

--- a/packages/components/src/separator/manifest.json
+++ b/packages/components/src/separator/manifest.json
@@ -1,0 +1,107 @@
+{
+  "name": "Separator",
+  "description": "A thin visual divider between content groups. Built on Base UI Separator with StyleX styling.",
+  "category": "layout",
+  "baseComponent": "@base-ui/react/separator",
+
+  "anatomy": "<Separator.Root />",
+
+  "parts": {
+    "Root": {
+      "element": "div",
+      "description": "A 1px line that adapts to its orientation. Uses colorBorderMuted to match in-component dividers (Menu, Sidebar).",
+      "props": {
+        "orientation": {
+          "type": "\"horizontal\" | \"vertical\"",
+          "default": "\"horizontal\"",
+          "description": "Direction of the separator. Vertical separators stretch to the height of their flex parent."
+        },
+        "decorative": {
+          "type": "boolean",
+          "default": "false",
+          "description": "When true, the separator is presentational only and exposes role=\"none\" to assistive technology."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects the current orientation (horizontal | vertical)."
+      }
+    }
+  },
+
+  "cssRequirements": null,
+
+  "tokens": ["colorBorderMuted"],
+
+  "intents": [
+    {
+      "intent": "section-divider",
+      "signals": [
+        "divider",
+        "separator",
+        "horizontal rule",
+        "hr",
+        "section break",
+        "split content"
+      ],
+      "reasoning": "Separator is the canonical 1px divider for splitting content groups, settings sections, or list groups.",
+      "composition": "<Separator.Root />"
+    },
+    {
+      "intent": "vertical-divider",
+      "signals": [
+        "vertical divider",
+        "inline separator",
+        "metadata separator",
+        "dot separator alternative"
+      ],
+      "reasoning": "Use orientation=\"vertical\" inside a flex row to separate inline metadata or toolbar groups.",
+      "composition": "<Separator.Root orientation=\"vertical\" />"
+    },
+    {
+      "intent": "decorative-divider",
+      "signals": ["decorative line", "visual divider", "non-semantic separator"],
+      "reasoning": "When the divider is purely visual and adjacent content is already grouped semantically, mark it decorative so screen readers skip it.",
+      "composition": "<Separator.Root decorative />"
+    }
+  ],
+
+  "avoidWhen": [
+    {
+      "scenario": "Replacing a heading or section landmark",
+      "reasoning": "Separator is decoration, not structure. Use a heading or landmark for semantic grouping.",
+      "alternative": "h2, h3, or <section> with aria-labelledby"
+    },
+    {
+      "scenario": "As a card or panel border",
+      "reasoning": "Containers should own their borders. Adding a Separator inside duplicates the visual.",
+      "alternative": "borderColor on the container"
+    },
+    {
+      "scenario": "Inside a Menu or Toolbar",
+      "reasoning": "Those components ship their own Separator part wired to their roving focus and ARIA model.",
+      "alternative": "Menu.Separator or Toolbar.Separator"
+    }
+  ],
+
+  "examples": [
+    {
+      "name": "horizontal",
+      "description": "Default horizontal divider between two stacked sections",
+      "code": "<>\n  <Section />\n  <Separator.Root />\n  <Section />\n</>"
+    },
+    {
+      "name": "vertical",
+      "description": "Vertical divider between inline metadata in a flex row",
+      "code": "<div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>\n  <span>Author</span>\n  <Separator.Root orientation=\"vertical\" />\n  <span>5 min read</span>\n</div>"
+    },
+    {
+      "name": "decorative",
+      "description": "Decorative variant for purely visual splits",
+      "code": "<Separator.Root decorative />"
+    }
+  ]
+}

--- a/packages/components/src/separator/separator.md
+++ b/packages/components/src/separator/separator.md
@@ -1,0 +1,65 @@
+# Separator
+
+A thin visual divider between content groups. Built on [Base UI Separator](https://base-ui.com/react/components/separator) with StyleX styling.
+
+## Import
+
+```tsx
+import { Separator } from '@basex-ui/components/separator';
+```
+
+## Anatomy
+
+```tsx
+<Separator.Root />
+```
+
+## Examples
+
+### Horizontal
+
+```tsx
+<Separator.Root />
+```
+
+### Vertical (inside a flex row)
+
+```tsx
+<div style={{ display: 'flex', alignItems: 'center', height: 24, gap: 12 }}>
+  <span>Left</span>
+  <Separator.Root orientation="vertical" />
+  <span>Right</span>
+</div>
+```
+
+### Decorative
+
+When the separator is purely visual and doesn't convey structure, set `decorative` to expose `role="none"` to assistive technology.
+
+```tsx
+<Separator.Root decorative />
+```
+
+## API Reference
+
+### Root
+
+A 1px line that adapts to its orientation. Uses the `colorBorderMuted` token to match in-component dividers (e.g. Menu, Sidebar). Renders a `<div>` with `role="separator"` by default, or `role="none"` when `decorative`.
+
+| Prop          | Type                         | Default        | Description                                                                                 |
+| ------------- | ---------------------------- | -------------- | ------------------------------------------------------------------------------------------- |
+| `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Direction of the separator. Vertical separators stretch to the height of their flex parent. |
+| `decorative`  | `boolean`                    | `false`        | When true, removes semantic role from accessibility tree (`role="none"`).                   |
+| `sx`          | `StyleXStyles`               | —              | Style overrides.                                                                            |
+
+## When to Use
+
+- **Section dividers** — between settings groups, list groups, toolbar groups
+- **Inline dividers** — between inline metadata (e.g. `Author · 5 min read`)
+- **Visual breathing room** — when whitespace alone isn't enough hierarchy
+
+## When NOT to Use
+
+- **Section headings** — Use a heading element; a Separator is not a substitute for structure.
+- **Card or panel borders** — Use the container's own border instead.
+- **List item delimiters that are themselves interactive** — Use a list with proper semantics.

--- a/packages/components/src/separator/separator.test.ts
+++ b/packages/components/src/separator/separator.test.ts
@@ -1,0 +1,53 @@
+import { vi, describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { createElement } from 'react';
+
+vi.mock('@stylexjs/stylex', () => {
+  const m = {
+    create: (s: Record<string, unknown>) => s,
+    props: () => ({ className: '' }),
+    defineVars: (v: Record<string, unknown>) => v,
+    createTheme: () => ({}),
+  };
+  return { default: m, ...m };
+});
+vi.mock('@basex-ui/tokens', () => ({
+  tokens: new Proxy({}, { get: (_, p) => `var(--${String(p)})` }),
+}));
+vi.mock('@basex-ui/styles', () => ({
+  focusRing: {},
+  capitalize: {},
+}));
+
+import { Separator } from './index';
+
+describe('Separator', () => {
+  it('exports Root part', () => {
+    expect(Separator.Root).toBeDefined();
+  });
+
+  it('sets displayName on Root', () => {
+    expect(Separator.Root.displayName).toBe('Separator.Root');
+  });
+
+  it('does not expose unexpected parts', () => {
+    expect(Object.keys(Separator).sort()).toEqual(['Root']);
+  });
+
+  it('renders horizontal with semantic role and aria-orientation', () => {
+    const html = renderToStaticMarkup(createElement(Separator.Root, {}));
+    expect(html).toContain('role="separator"');
+    expect(html).toContain('aria-orientation="horizontal"');
+  });
+
+  it('renders vertical orientation', () => {
+    const html = renderToStaticMarkup(createElement(Separator.Root, { orientation: 'vertical' }));
+    expect(html).toContain('aria-orientation="vertical"');
+  });
+
+  it('decorative variant exposes role="none" and no aria-orientation', () => {
+    const html = renderToStaticMarkup(createElement(Separator.Root, { decorative: true }));
+    expect(html).toContain('role="none"');
+    expect(html).not.toContain('aria-orientation');
+  });
+});

--- a/packages/components/src/separator/separator.tsx
+++ b/packages/components/src/separator/separator.tsx
@@ -1,0 +1,59 @@
+import { Separator as BaseSeparator } from '@base-ui/react/separator';
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { forwardRef } from 'react';
+import type { StyleXStyles } from '@stylexjs/stylex';
+
+// --- Styles ---
+const styles = stylex.create({
+  horizontal: {
+    width: '100%',
+    height: '1px',
+    backgroundColor: tokens.colorBorderMuted,
+    flexShrink: 0,
+    border: 0,
+  },
+  vertical: {
+    width: '1px',
+    height: '100%',
+    alignSelf: 'stretch',
+    backgroundColor: tokens.colorBorderMuted,
+    flexShrink: 0,
+    border: 0,
+  },
+});
+
+// --- Types ---
+export interface SeparatorRootProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSeparator>,
+  'className'
+> {
+  /**
+   * When true, the separator is purely visual and exposes `role="none"` to
+   * assistive technologies. Use this when the separator does not communicate
+   * meaningful structure (e.g. a thin divider between two related toolbar groups).
+   * @default false
+   */
+  decorative?: boolean;
+  sx?: StyleXStyles;
+}
+
+// --- Component ---
+const Root = forwardRef<HTMLDivElement, SeparatorRootProps>(
+  ({ orientation = 'horizontal', decorative = false, sx, ...props }, ref) => (
+    <BaseSeparator
+      ref={ref}
+      orientation={orientation}
+      {...(decorative ? { role: 'none', 'aria-orientation': undefined } : {})}
+      {...props}
+      className={
+        stylex.props(orientation === 'vertical' ? styles.vertical : styles.horizontal, sx)
+          .className ?? ''
+      }
+    />
+  ),
+);
+Root.displayName = 'Separator.Root';
+
+// --- Public API ---
+export const Separator = { Root };

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     'src/preview-card/index.ts',
     'src/progress/index.ts',
     'src/radio/index.ts',
+    'src/separator/index.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/intelligence/intents.json
+++ b/packages/intelligence/intents.json
@@ -534,6 +534,39 @@
       "signals": ["preference", "settings choice", "plan selection", "tier", "mode selector"],
       "reasoning": "Radio groups work well for preference or settings where users pick exactly one option from a small set.",
       "composition": "<Radio.Group defaultValue=\"standard\">\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"standard\"><Radio.Indicator /></Radio.Root>\n    Standard\n  </label>\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"express\"><Radio.Indicator /></Radio.Root>\n    Express\n  </label>\n</Radio.Group>"
+    },
+    {
+      "intent": "section-divider",
+      "component": "Separator",
+      "signals": [
+        "divider",
+        "separator",
+        "horizontal rule",
+        "hr",
+        "section break",
+        "split content"
+      ],
+      "reasoning": "Separator is the canonical 1px divider for splitting content groups, settings sections, or list groups.",
+      "composition": "<Separator.Root />"
+    },
+    {
+      "intent": "vertical-divider",
+      "component": "Separator",
+      "signals": [
+        "vertical divider",
+        "inline separator",
+        "metadata separator",
+        "dot separator alternative"
+      ],
+      "reasoning": "Use orientation=\"vertical\" inside a flex row to separate inline metadata or toolbar groups.",
+      "composition": "<Separator.Root orientation=\"vertical\" />"
+    },
+    {
+      "intent": "decorative-divider",
+      "component": "Separator",
+      "signals": ["decorative line", "visual divider", "non-semantic separator"],
+      "reasoning": "When the divider is purely visual and adjacent content is already grouped semantically, mark it decorative so screen readers skip it.",
+      "composition": "<Separator.Root decorative />"
     }
   ],
   "antiPatterns": [
@@ -956,6 +989,24 @@
       "scenario": "Binary on/off toggle",
       "reasoning": "Use Switch for a single boolean toggle. Radio is for choosing between labeled options.",
       "alternative": "Switch"
+    },
+    {
+      "component": "Separator",
+      "scenario": "Replacing a heading or section landmark",
+      "reasoning": "Separator is decoration, not structure. Use a heading or landmark for semantic grouping.",
+      "alternative": "h2, h3, or <section> with aria-labelledby"
+    },
+    {
+      "component": "Separator",
+      "scenario": "As a card or panel border",
+      "reasoning": "Containers should own their borders. Adding a Separator inside duplicates the visual.",
+      "alternative": "borderColor on the container"
+    },
+    {
+      "component": "Separator",
+      "scenario": "Inside a Menu or Toolbar",
+      "reasoning": "Those components ship their own Separator part wired to their roving focus and ARIA model.",
+      "alternative": "Menu.Separator or Toolbar.Separator"
     }
   ]
 }

--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -13,7 +13,7 @@ describe('listComponents', () => {
     const names = list.map((c) => c.name);
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
-    expect(list).toHaveLength(24);
+    expect(list).toHaveLength(25);
   });
 });
 

--- a/packages/mcp-server/src/data.ts
+++ b/packages/mcp-server/src/data.ts
@@ -38,6 +38,7 @@ import popoverManifest from '../../components/src/popover/manifest.json';
 import previewCardManifest from '../../components/src/preview-card/manifest.json';
 import progressManifest from '../../components/src/progress/manifest.json';
 import radioManifest from '../../components/src/radio/manifest.json';
+import separatorManifest from '../../components/src/separator/manifest.json';
 
 export type ComponentManifest =
   | typeof buttonManifest
@@ -63,7 +64,8 @@ export type ComponentManifest =
   | typeof popoverManifest
   | typeof previewCardManifest
   | typeof progressManifest
-  | typeof radioManifest;
+  | typeof radioManifest
+  | typeof separatorManifest;
 
 const components = new Map<string, ComponentManifest>([
   ['button', buttonManifest],
@@ -90,6 +92,7 @@ const components = new Map<string, ComponentManifest>([
   ['preview-card', previewCardManifest],
   ['progress', progressManifest],
   ['radio', radioManifest],
+  ['separator', separatorManifest],
 ] as [string, ComponentManifest][]);
 
 // ---------------------------------------------------------------------------
@@ -262,6 +265,7 @@ export function getComponentSetup(name: string): ComponentSetup | null {
       { interaction: 'indeterminate animation', preset: 'Move' },
     ],
     radio: [{ interaction: 'indicator appear/disappear', preset: 'State' }],
+    separator: [],
   };
 
   return {


### PR DESCRIPTION
## Summary

Headless, accessible 1px Separator (component #28). Single Root part, orientations `horizontal` | `vertical`, and a `decorative` variant that exposes `role="none"`.

## Tokens used

- `colorBorderMuted` — copied from `Menu.Separator` (and matches the sidebar/header bottom borders in `apps/docs/src/App.tsx`). This keeps in-component dividers and standalone Separators visually identical.

No new tokens introduced.

## ARIA decisions

- Default: Base UI's `Separator` already renders `role="separator"` + `aria-orientation`. Left untouched.
- `decorative`: spreads `role="none"` and forces `aria-orientation` off so screen readers skip it. Matches WAI-ARIA's guidance for purely visual dividers.
- No focus, no interactivity → no `focusRing`, no disabled state.

## Files

- `packages/components/src/separator/{separator.tsx, index.ts, manifest.json, separator.md, separator.test.ts}`
- Wired into barrel, package exports, tsup entries, MCP data, intelligence intents, docs registry/api-docs, roadmap.
- Bumped `packages/mcp-server/src/data.test.ts` length assertion 24 → 25.

## Test plan

- [x] `pnpm -w build` — green
- [x] `pnpm -w test:ci` — 13 files / 62 tests passing (6 new for Separator covering both orientations + decorative ARIA)
- [x] `pnpm -w lint` — only the pre-existing App.tsx `useEffect` warning
- [x] `pnpm format:check` — clean

## What needs review

Probably nothing. Worth a glance:
- Decorative implementation spreads `role`/`aria-orientation` overrides via a conditional spread before `...props` — if a consumer wants to force-set those, their props still win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)