### PR TITLE
feat: add Tabs component

### DIFF
--- a/apps/docs/src/content/api-docs.ts
+++ b/apps/docs/src/content/api-docs.ts
@@ -22,6 +22,7 @@ import popover from '../../../../packages/components/src/popover/popover.md?raw'
 import previewCard from '../../../../packages/components/src/preview-card/preview-card.md?raw';
 import progress from '../../../../packages/components/src/progress/progress.md?raw';
 import radio from '../../../../packages/components/src/radio/radio.md?raw';
+import tabs from '../../../../packages/components/src/tabs/tabs.md?raw';
 
 export const apiDocs: Record<string, string> = {
   accordion,
@@ -48,4 +49,5 @@ export const apiDocs: Record<string, string> = {
   'preview-card': previewCard,
   progress,
   radio,
+  tabs,
 };

--- a/apps/docs/src/index.css
+++ b/apps/docs/src/index.css
@@ -393,6 +393,14 @@
     border-color: var(--colorPrimary);
     background-color: var(--colorPrimary);
   }
+
+  /* Tabs indicator — slide to active tab. Move preset: 200ms ease-in-out. */
+  /* Position is driven by Base UI CSS vars set on Tabs.Indicator. */
+  @media (prefers-reduced-motion: reduce) {
+    .basex-tabs-indicator {
+      transition-duration: 0ms !important;
+    }
+  }
 }
 
 body {

--- a/apps/docs/src/pages/TabsPage.tsx
+++ b/apps/docs/src/pages/TabsPage.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { Field, Input, Tabs } from '@basex-ui/components';
+import { Preview } from '../components/Preview';
+
+const styles = stylex.create({
+  panel: {
+    paddingBlock: tokens.space3,
+    color: tokens.colorTextMuted,
+    fontFamily: tokens.fontFamilyMono,
+    fontSize: tokens.fontSizeSm,
+    lineHeight: tokens.lineHeightNormal,
+  },
+  formPanel: {
+    paddingBlock: tokens.space3,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.space3,
+    minWidth: '16rem',
+  },
+});
+
+export function TabsPage() {
+  const [controlled, setControlled] = useState<string | number | null>('overview');
+
+  return (
+    <>
+      <Preview
+        title="Basic"
+        description="Horizontal tabs with an animated indicator. Automatic activation: focus a tab and it activates."
+        code={`<Tabs.Root defaultValue="overview">
+  <Tabs.List>
+    <Tabs.Tab value="overview">Overview</Tabs.Tab>
+    <Tabs.Tab value="details">Details</Tabs.Tab>
+    <Tabs.Tab value="activity">Activity</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="overview">Overview content</Tabs.Panel>
+  <Tabs.Panel value="details">Details content</Tabs.Panel>
+  <Tabs.Panel value="activity">Activity content</Tabs.Panel>
+</Tabs.Root>`}
+      >
+        <Tabs.Root defaultValue="overview">
+          <Tabs.List>
+            <Tabs.Tab value="overview">Overview</Tabs.Tab>
+            <Tabs.Tab value="details">Details</Tabs.Tab>
+            <Tabs.Tab value="activity">Activity</Tabs.Tab>
+            <Tabs.Indicator />
+          </Tabs.List>
+          <Tabs.Panel value="overview" sx={styles.panel}>
+            Overview content for the project.
+          </Tabs.Panel>
+          <Tabs.Panel value="details" sx={styles.panel}>
+            Detailed specs and metadata.
+          </Tabs.Panel>
+          <Tabs.Panel value="activity" sx={styles.panel}>
+            Recent activity feed.
+          </Tabs.Panel>
+        </Tabs.Root>
+      </Preview>
+
+      <Preview
+        title="Vertical"
+        description="Vertical orientation with the indicator on the inline-end edge. Suitable for settings panels."
+        code={`<Tabs.Root orientation="vertical" defaultValue="profile">
+  <Tabs.List>
+    <Tabs.Tab value="profile">Profile</Tabs.Tab>
+    <Tabs.Tab value="account">Account</Tabs.Tab>
+    <Tabs.Tab value="notifications">Notifications</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="profile">Profile fields</Tabs.Panel>
+  <Tabs.Panel value="account">Account fields</Tabs.Panel>
+  <Tabs.Panel value="notifications">Notifications</Tabs.Panel>
+</Tabs.Root>`}
+      >
+        <Tabs.Root orientation="vertical" defaultValue="profile">
+          <Tabs.List>
+            <Tabs.Tab value="profile">Profile</Tabs.Tab>
+            <Tabs.Tab value="account">Account</Tabs.Tab>
+            <Tabs.Tab value="notifications">Notifications</Tabs.Tab>
+            <Tabs.Indicator />
+          </Tabs.List>
+          <Tabs.Panel value="profile" sx={styles.panel}>
+            Profile fields go here.
+          </Tabs.Panel>
+          <Tabs.Panel value="account" sx={styles.panel}>
+            Account settings go here.
+          </Tabs.Panel>
+          <Tabs.Panel value="notifications" sx={styles.panel}>
+            Notification preferences.
+          </Tabs.Panel>
+        </Tabs.Root>
+      </Preview>
+
+      <Preview
+        title="Manual activation"
+        description="Focus moves with arrow keys, but Enter/Space is required to activate. Recommended when panels contain interactive content."
+        code={`<Tabs.Root defaultValue="a">
+  <Tabs.List activationMode="manual">
+    <Tabs.Tab value="a">A</Tabs.Tab>
+    <Tabs.Tab value="b">B</Tabs.Tab>
+    <Tabs.Tab value="c">C</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="a">A</Tabs.Panel>
+  <Tabs.Panel value="b">B</Tabs.Panel>
+  <Tabs.Panel value="c">C</Tabs.Panel>
+</Tabs.Root>`}
+      >
+        <Tabs.Root defaultValue="a">
+          <Tabs.List activationMode="manual">
+            <Tabs.Tab value="a">A</Tabs.Tab>
+            <Tabs.Tab value="b">B</Tabs.Tab>
+            <Tabs.Tab value="c">C</Tabs.Tab>
+            <Tabs.Indicator />
+          </Tabs.List>
+          <Tabs.Panel value="a" sx={styles.panel}>
+            Panel A
+          </Tabs.Panel>
+          <Tabs.Panel value="b" sx={styles.panel}>
+            Panel B
+          </Tabs.Panel>
+          <Tabs.Panel value="c" sx={styles.panel}>
+            Panel C
+          </Tabs.Panel>
+        </Tabs.Root>
+      </Preview>
+
+      <Preview
+        title="With form content"
+        description="Tabs with form fields. Manual activation prevents arrow-key navigation from blowing away in-progress input."
+        code={`<Tabs.Root defaultValue="profile">
+  <Tabs.List activationMode="manual">
+    <Tabs.Tab value="profile">Profile</Tabs.Tab>
+    <Tabs.Tab value="address">Address</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="profile">
+    <Field.Root>
+      <Field.Label>Name</Field.Label>
+      <Input />
+    </Field.Root>
+  </Tabs.Panel>
+  <Tabs.Panel value="address">
+    <Field.Root>
+      <Field.Label>City</Field.Label>
+      <Input />
+    </Field.Root>
+  </Tabs.Panel>
+</Tabs.Root>`}
+      >
+        <Tabs.Root defaultValue="profile">
+          <Tabs.List activationMode="manual">
+            <Tabs.Tab value="profile">Profile</Tabs.Tab>
+            <Tabs.Tab value="address">Address</Tabs.Tab>
+            <Tabs.Indicator />
+          </Tabs.List>
+          <Tabs.Panel value="profile" sx={styles.formPanel}>
+            <Field.Root>
+              <Field.Label>Name</Field.Label>
+              <Input placeholder="Jane Doe" />
+            </Field.Root>
+            <Field.Root>
+              <Field.Label>Email</Field.Label>
+              <Input type="email" placeholder="jane@example.com" />
+            </Field.Root>
+          </Tabs.Panel>
+          <Tabs.Panel value="address" sx={styles.formPanel}>
+            <Field.Root>
+              <Field.Label>City</Field.Label>
+              <Input placeholder="San Francisco" />
+            </Field.Root>
+            <Field.Root>
+              <Field.Label>Country</Field.Label>
+              <Input placeholder="USA" />
+            </Field.Root>
+          </Tabs.Panel>
+        </Tabs.Root>
+      </Preview>
+
+      <Preview
+        title="Controlled"
+        description="External state drives the active tab via value + onValueChange."
+        code={`const [value, setValue] = useState('overview');
+<Tabs.Root value={value} onValueChange={setValue}>
+  <Tabs.List>
+    <Tabs.Tab value="overview">Overview</Tabs.Tab>
+    <Tabs.Tab value="details">Details</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  ...
+</Tabs.Root>`}
+      >
+        <Tabs.Root value={controlled} onValueChange={(v) => setControlled(v)}>
+          <Tabs.List>
+            <Tabs.Tab value="overview">Overview</Tabs.Tab>
+            <Tabs.Tab value="details">Details</Tabs.Tab>
+            <Tabs.Indicator />
+          </Tabs.List>
+          <Tabs.Panel value="overview" sx={styles.panel}>
+            Active value: <code>{String(controlled)}</code>
+          </Tabs.Panel>
+          <Tabs.Panel value="details" sx={styles.panel}>
+            Active value: <code>{String(controlled)}</code>
+          </Tabs.Panel>
+        </Tabs.Root>
+      </Preview>
+    </>
+  );
+}

--- a/apps/docs/src/pages/TabsPage.tsx
+++ b/apps/docs/src/pages/TabsPage.tsx
@@ -11,13 +11,18 @@ const styles = stylex.create({
     fontFamily: tokens.fontFamilyMono,
     fontSize: tokens.fontSizeSm,
     lineHeight: tokens.lineHeightNormal,
+    // Lock the panel area so switching tabs with different content lengths
+    // does not reflow the surrounding bounding box.
+    minWidth: '20rem',
+    minHeight: '3rem',
   },
   formPanel: {
     paddingBlock: tokens.space3,
     display: 'flex',
     flexDirection: 'column',
     gap: tokens.space3,
-    minWidth: '16rem',
+    minWidth: '20rem',
+    minHeight: '8rem',
   },
 });
 

--- a/apps/docs/src/pages/TabsPage.tsx
+++ b/apps/docs/src/pages/TabsPage.tsx
@@ -28,7 +28,7 @@ export function TabsPage() {
     <>
       <Preview
         title="Basic"
-        description="Horizontal tabs with an animated indicator. Automatic activation: focus a tab and it activates."
+        description="Horizontal tabs with a filled-block active state. Automatic activation: focus a tab and it activates."
         code={`<Tabs.Root defaultValue="overview">
   <Tabs.List>
     <Tabs.Tab value="overview">Overview</Tabs.Tab>
@@ -62,7 +62,7 @@ export function TabsPage() {
 
       <Preview
         title="Vertical"
-        description="Vertical orientation with the indicator on the inline-end edge. Suitable for settings panels."
+        description="Vertical orientation, filled-block active state. Suitable for settings panels."
         code={`<Tabs.Root orientation="vertical" defaultValue="profile">
   <Tabs.List>
     <Tabs.Tab value="profile">Profile</Tabs.Tab>

--- a/apps/docs/src/registry.ts
+++ b/apps/docs/src/registry.ts
@@ -24,6 +24,7 @@ import { PopoverPage } from './pages/PopoverPage';
 import { PreviewCardPage } from './pages/PreviewCardPage';
 import { ProgressPage } from './pages/ProgressPage';
 import { RadioPage } from './pages/RadioPage';
+import { TabsPage } from './pages/TabsPage';
 
 export interface PageEntry {
   id: string;
@@ -262,6 +263,14 @@ export const pages: PageEntry[] = [
     path: '/components/radio',
     section: 'components',
     component: RadioPage,
+  },
+  {
+    id: 'tabs',
+    label: 'Tabs',
+    description: 'Switch between sibling content panels with full keyboard support and an animated indicator.',
+    path: '/components/tabs',
+    section: 'components',
+    component: TabsPage,
   },
 
   // Intelligence section

--- a/apps/docs/src/registry.ts
+++ b/apps/docs/src/registry.ts
@@ -267,7 +267,8 @@ export const pages: PageEntry[] = [
   {
     id: 'tabs',
     label: 'Tabs',
-    description: 'Switch between sibling content panels with full keyboard support and an animated indicator.',
+    description:
+      'Switch between sibling content panels with full keyboard support and an animated indicator.',
     path: '/components/tabs',
     section: 'components',
     component: TabsPage,

--- a/docs/plans/component-roadmap.md
+++ b/docs/plans/component-roadmap.md
@@ -38,7 +38,7 @@
 | 28  | Separator       | `Separator`      | —        |              |
 | 29  | Slider          | `Slider`         | —        |              |
 | 30  | Switch          | `Switch`         | —        |              |
-| 31  | Tabs            | `Tabs`           | —        |              |
+| 31  | Tabs            | `Tabs`           | Done     |              |
 | 32  | Toast           | `Toast`          | —        |              |
 | 33  | Toggle          | `Toggle`         | —        |              |
 | 34  | Toggle Group    | `ToggleGroup`    | —        |              |
@@ -47,7 +47,7 @@
 
 ## Progress
 
-- **Done**: 25 / 36
+- **Done**: 26 / 36
 - **Next**: Scroll Area
 
 ## How to Use This File

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -120,6 +120,10 @@
     "./radio": {
       "types": "./dist/radio/index.d.ts",
       "import": "./dist/radio/index.js"
+    },
+    "./tabs": {
+      "types": "./dist/tabs/index.d.ts",
+      "import": "./dist/tabs/index.js"
     }
   },
   "files": [

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -220,3 +220,13 @@ export type {
   RadioRootProps,
   RadioIndicatorProps,
 } from './radio';
+
+export { Tabs } from './tabs';
+export type {
+  TabsActivationMode,
+  TabsRootProps,
+  TabsListProps,
+  TabsTabProps,
+  TabsPanelProps,
+  TabsIndicatorProps,
+} from './tabs';

--- a/packages/components/src/tabs/index.ts
+++ b/packages/components/src/tabs/index.ts
@@ -1,0 +1,9 @@
+export { Tabs } from './tabs';
+export type {
+  TabsActivationMode,
+  TabsRootProps,
+  TabsListProps,
+  TabsTabProps,
+  TabsPanelProps,
+  TabsIndicatorProps,
+} from './tabs';

--- a/packages/components/src/tabs/manifest.json
+++ b/packages/components/src/tabs/manifest.json
@@ -1,0 +1,229 @@
+{
+  "name": "Tabs",
+  "description": "An accessible tab interface that organizes content into selectable panels. Built on Base UI Tabs with StyleX styling.",
+  "category": "navigation",
+  "baseComponent": "@base-ui/react/tabs",
+
+  "anatomy": "<Tabs.Root>\n  <Tabs.List>\n    <Tabs.Tab value=\"a\">Tab A</Tabs.Tab>\n    <Tabs.Tab value=\"b\">Tab B</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"a\">Panel A</Tabs.Panel>\n  <Tabs.Panel value=\"b\">Panel B</Tabs.Panel>\n</Tabs.Root>",
+
+  "parts": {
+    "Root": {
+      "element": "div",
+      "description": "The Tabs container. Provides state and orientation context.",
+      "props": {
+        "value": {
+          "type": "string | number | null",
+          "description": "The value of the currently active tab (controlled)."
+        },
+        "defaultValue": {
+          "type": "string | number | null",
+          "default": "0",
+          "description": "The initially active tab (uncontrolled)."
+        },
+        "onValueChange": {
+          "type": "(value, eventDetails) => void",
+          "description": "Callback when the active tab changes."
+        },
+        "orientation": {
+          "type": "'horizontal' | 'vertical'",
+          "default": "horizontal",
+          "description": "Layout flow direction. Affects keyboard nav and indicator orientation."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects the orientation of the tabs."
+      }
+    },
+    "List": {
+      "element": "div",
+      "description": "Container for the tab buttons. Renders with role=\"tablist\".",
+      "props": {
+        "activationMode": {
+          "type": "'automatic' | 'manual'",
+          "default": "automatic",
+          "description": "Whether tabs activate as they receive focus (automatic) or only on Enter/Space (manual)."
+        },
+        "loopFocus": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether arrow-key focus loops at the ends of the list."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects the orientation."
+      }
+    },
+    "Tab": {
+      "element": "button",
+      "description": "An individual tab button. Renders with role=\"tab\" and is wired to its panel via aria-controls/aria-selected.",
+      "props": {
+        "value": {
+          "type": "string | number",
+          "required": true,
+          "description": "The value identifying this tab. Matches Tabs.Panel value."
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the tab is disabled."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-selected": "Present when the tab is active.",
+        "data-disabled": "Present when the tab is disabled.",
+        "data-orientation": "Reflects the orientation."
+      }
+    },
+    "Panel": {
+      "element": "div",
+      "description": "The content panel for a tab. Renders with role=\"tabpanel\".",
+      "props": {
+        "value": {
+          "type": "string | number",
+          "required": true,
+          "description": "The value of the tab this panel belongs to."
+        },
+        "keepMounted": {
+          "type": "boolean",
+          "default": false,
+          "description": "Keep the panel mounted in the DOM when hidden."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects the orientation.",
+        "data-hidden": "Present when the panel is hidden."
+      }
+    },
+    "Indicator": {
+      "element": "span",
+      "description": "An animated visual indicator that aligns to the active tab. Reads --active-tab-left/-top/-width/-height CSS vars from Base UI.",
+      "props": {
+        "renderBeforeHydration": {
+          "type": "boolean",
+          "default": false,
+          "description": "Render before React hydrates to minimize SSR flicker."
+        },
+        "sx": {
+          "type": "StyleXStyles",
+          "description": "StyleX styles for consumer overrides."
+        }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects the orientation.",
+        "data-activation-direction": "left | right | up | down | none"
+      }
+    }
+  },
+
+  "cssRequirements": null,
+
+  "tokens": [
+    "colorText",
+    "colorTextMuted",
+    "colorMuted",
+    "colorBorderMuted",
+    "colorFocusRing",
+    "space1",
+    "space1h",
+    "space2",
+    "space3",
+    "space4",
+    "fontFamilySans",
+    "fontSizeSm",
+    "fontWeightMedium",
+    "lineHeightTight",
+    "lineHeightNormal",
+    "radiusMd",
+    "radiusFull",
+    "borderWidthDefault",
+    "motionDurationFast",
+    "motionDurationNormal",
+    "motionEaseOut",
+    "motionEaseInOut"
+  ],
+
+  "intents": [
+    {
+      "intent": "tabbed-content",
+      "signals": [
+        "tabs",
+        "tabbed",
+        "tab interface",
+        "switch between views",
+        "tabbed sections",
+        "panel switcher"
+      ],
+      "reasoning": "Tabs is the canonical component for switching between mutually exclusive content panels at the same level of hierarchy.",
+      "composition": "<Tabs.Root defaultValue=\"overview\">\n  <Tabs.List>\n    <Tabs.Tab value=\"overview\">Overview</Tabs.Tab>\n    <Tabs.Tab value=\"details\">Details</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"overview\">Overview content</Tabs.Panel>\n  <Tabs.Panel value=\"details\">Details content</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "intent": "settings-sections",
+      "signals": ["settings tabs", "preferences tabs", "vertical tabs", "side tabs"],
+      "reasoning": "Vertical Tabs work well for settings UIs where users move between configuration groups.",
+      "composition": "<Tabs.Root orientation=\"vertical\" defaultValue=\"profile\">\n  <Tabs.List>\n    <Tabs.Tab value=\"profile\">Profile</Tabs.Tab>\n    <Tabs.Tab value=\"account\">Account</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"profile\">Profile fields</Tabs.Panel>\n  <Tabs.Panel value=\"account\">Account fields</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "intent": "form-with-tabs",
+      "signals": ["multi-step form", "tabbed form", "form sections"],
+      "reasoning": "Use manual activation when tab content includes form controls, so screen readers don't trigger panel changes during arrow-key navigation.",
+      "composition": "<Tabs.Root defaultValue=\"step1\">\n  <Tabs.List activationMode=\"manual\">\n    <Tabs.Tab value=\"step1\">Step 1</Tabs.Tab>\n    <Tabs.Tab value=\"step2\">Step 2</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"step1\">{/* form fields */}</Tabs.Panel>\n  <Tabs.Panel value=\"step2\">{/* form fields */}</Tabs.Panel>\n</Tabs.Root>"
+    }
+  ],
+
+  "avoidWhen": [
+    {
+      "scenario": "Sequential steps that must be completed in order",
+      "reasoning": "Tabs imply free navigation between siblings. For ordered flows, use a stepper or wizard pattern.",
+      "alternative": "Custom stepper"
+    },
+    {
+      "scenario": "Site-wide navigation between pages",
+      "reasoning": "Tabs are for content within a single view. Use NavigationMenu for top-level site nav.",
+      "alternative": "NavigationMenu"
+    },
+    {
+      "scenario": "Many sections (more than ~7) or long labels that wrap",
+      "reasoning": "Tab lists work best with a small number of short labels. Use Accordion or a sidebar nav for larger sets.",
+      "alternative": "Accordion"
+    }
+  ],
+
+  "examples": [
+    {
+      "name": "basic",
+      "description": "Basic horizontal tabs with an animated indicator.",
+      "code": "<Tabs.Root defaultValue=\"overview\">\n  <Tabs.List>\n    <Tabs.Tab value=\"overview\">Overview</Tabs.Tab>\n    <Tabs.Tab value=\"details\">Details</Tabs.Tab>\n    <Tabs.Tab value=\"activity\">Activity</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"overview\">Overview content</Tabs.Panel>\n  <Tabs.Panel value=\"details\">Details content</Tabs.Panel>\n  <Tabs.Panel value=\"activity\">Activity content</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "name": "vertical",
+      "description": "Vertical tabs suitable for settings panels.",
+      "code": "<Tabs.Root orientation=\"vertical\" defaultValue=\"profile\">\n  <Tabs.List>\n    <Tabs.Tab value=\"profile\">Profile</Tabs.Tab>\n    <Tabs.Tab value=\"account\">Account</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"profile\">Profile fields</Tabs.Panel>\n  <Tabs.Panel value=\"account\">Account fields</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "name": "manual-activation",
+      "description": "Manual activation: focus moves with arrow keys, but Enter/Space is required to activate.",
+      "code": "<Tabs.Root defaultValue=\"a\">\n  <Tabs.List activationMode=\"manual\">\n    <Tabs.Tab value=\"a\">A</Tabs.Tab>\n    <Tabs.Tab value=\"b\">B</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"a\">A</Tabs.Panel>\n  <Tabs.Panel value=\"b\">B</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "name": "controlled",
+      "description": "Controlled tabs with external state.",
+      "code": "const [value, setValue] = useState('a');\n<Tabs.Root value={value} onValueChange={setValue}>\n  <Tabs.List>\n    <Tabs.Tab value=\"a\">A</Tabs.Tab>\n    <Tabs.Tab value=\"b\">B</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"a\">A</Tabs.Panel>\n  <Tabs.Panel value=\"b\">B</Tabs.Panel>\n</Tabs.Root>"
+    }
+  ]
+}

--- a/packages/components/src/tabs/tabs.md
+++ b/packages/components/src/tabs/tabs.md
@@ -20,7 +20,7 @@ An accessible tab interface that organizes content into selectable panels. Built
 - **List** -- The tab strip (`role="tablist"`).
 - **Tab** -- An individual tab button (`role="tab"`, with `aria-controls` / `aria-selected`).
 - **Panel** -- The content panel for a tab (`role="tabpanel"`).
-- **Indicator** -- An optional animated indicator that aligns to the active tab.
+- **Indicator** -- An optional active-tab indicator. BaseX UI's default styling expresses the active state through a filled block on the active tab itself, so `<Tabs.Indicator />` is a no-op visually unless you override its `sx`. Kept as part of the public API so consumers can opt into a custom indicator (e.g. underline) by overriding the `display: none` default.
 
 ## Examples
 
@@ -104,17 +104,13 @@ An accessible tab interface that organizes content into selectable panels. Built
 
 With `activationMode="automatic"` (default) tabs activate on focus. With `activationMode="manual"`, focus and activation are decoupled — preferred when panels contain forms.
 
-## Reduced motion
+## Visual style
 
-The indicator transitions are wired through standard CSS transitions; consumers can opt their app into `prefers-reduced-motion` overrides via the global stylesheet:
-
-```css
-@media (prefers-reduced-motion: reduce) {
-  .basex-tabs-indicator {
-    transition-duration: 0ms !important;
-  }
-}
-```
+Active tabs render as a solid filled block in the foreground neutral
+(`colorText`) with the inverse text color (`colorTextInverse`). Inactive tabs
+are bare text in `colorTextMuted` on the surrounding surface, with a subtle
+`colorMuted` hover tint. Corners are squared (`radiusSm` = 0). The aim is a
+Spotify-style nav: the current selection is unmistakable, never subtle.
 
 ## API Reference
 

--- a/packages/components/src/tabs/tabs.md
+++ b/packages/components/src/tabs/tabs.md
@@ -94,13 +94,13 @@ An accessible tab interface that organizes content into selectable panels. Built
 
 ## Keyboard
 
-| Key                                | Behavior                                                          |
-| ---------------------------------- | ----------------------------------------------------------------- |
-| `Tab`                              | Move focus into the tab list.                                     |
-| `ArrowLeft` / `ArrowRight`         | Move focus between tabs (horizontal). RTL-safe.                   |
-| `ArrowUp` / `ArrowDown`            | Move focus between tabs (vertical).                               |
-| `Home` / `End`                     | Move focus to the first/last tab.                                 |
-| `Enter` / `Space`                  | Activate the focused tab (required only with `manual` activation). |
+| Key                        | Behavior                                                           |
+| -------------------------- | ------------------------------------------------------------------ |
+| `Tab`                      | Move focus into the tab list.                                      |
+| `ArrowLeft` / `ArrowRight` | Move focus between tabs (horizontal). RTL-safe.                    |
+| `ArrowUp` / `ArrowDown`    | Move focus between tabs (vertical).                                |
+| `Home` / `End`             | Move focus to the first/last tab.                                  |
+| `Enter` / `Space`          | Activate the focused tab (required only with `manual` activation). |
 
 With `activationMode="automatic"` (default) tabs activate on focus. With `activationMode="manual"`, focus and activation are decoupled — preferred when panels contain forms.
 
@@ -120,63 +120,63 @@ The indicator transitions are wired through standard CSS transitions; consumers 
 
 ### Tabs.Root
 
-| Prop            | Type                                       | Default        | Description                                  |
-| --------------- | ------------------------------------------ | -------------- | -------------------------------------------- |
-| `value`         | `string \| number \| null`                 | --             | The active tab value (controlled).           |
-| `defaultValue`  | `string \| number \| null`                 | `0`            | The initially active tab (uncontrolled).     |
-| `onValueChange` | `(value, eventDetails) => void`            | --             | Callback when the active tab changes.        |
-| `orientation`   | `'horizontal' \| 'vertical'`               | `'horizontal'` | Layout flow direction.                       |
-| `sx`            | `StyleXStyles`                             | --             | StyleX styles for consumer overrides.        |
+| Prop            | Type                            | Default        | Description                              |
+| --------------- | ------------------------------- | -------------- | ---------------------------------------- |
+| `value`         | `string \| number \| null`      | --             | The active tab value (controlled).       |
+| `defaultValue`  | `string \| number \| null`      | `0`            | The initially active tab (uncontrolled). |
+| `onValueChange` | `(value, eventDetails) => void` | --             | Callback when the active tab changes.    |
+| `orientation`   | `'horizontal' \| 'vertical'`    | `'horizontal'` | Layout flow direction.                   |
+| `sx`            | `StyleXStyles`                  | --             | StyleX styles for consumer overrides.    |
 
 ### Tabs.List
 
-| Prop             | Type                          | Default       | Description                                                            |
-| ---------------- | ----------------------------- | ------------- | ---------------------------------------------------------------------- |
-| `activationMode` | `'automatic' \| 'manual'`     | `'automatic'` | Whether tabs activate on focus (`automatic`) or only on Enter/Space.   |
-| `loopFocus`      | `boolean`                     | `true`        | Whether arrow-key focus loops at the ends of the list.                 |
-| `sx`             | `StyleXStyles`                | --            | StyleX styles for consumer overrides.                                  |
+| Prop             | Type                      | Default       | Description                                                          |
+| ---------------- | ------------------------- | ------------- | -------------------------------------------------------------------- |
+| `activationMode` | `'automatic' \| 'manual'` | `'automatic'` | Whether tabs activate on focus (`automatic`) or only on Enter/Space. |
+| `loopFocus`      | `boolean`                 | `true`        | Whether arrow-key focus loops at the ends of the list.               |
+| `sx`             | `StyleXStyles`            | --            | StyleX styles for consumer overrides.                                |
 
 ### Tabs.Tab
 
-| Prop       | Type                | Default | Description                              |
-| ---------- | ------------------- | ------- | ---------------------------------------- |
-| `value`    | `string \| number`  | --      | Required. Identifies this tab.           |
-| `disabled` | `boolean`           | `false` | Whether the tab is disabled.             |
-| `sx`       | `StyleXStyles`      | --      | StyleX styles for consumer overrides.    |
+| Prop       | Type               | Default | Description                           |
+| ---------- | ------------------ | ------- | ------------------------------------- |
+| `value`    | `string \| number` | --      | Required. Identifies this tab.        |
+| `disabled` | `boolean`          | `false` | Whether the tab is disabled.          |
+| `sx`       | `StyleXStyles`     | --      | StyleX styles for consumer overrides. |
 
 #### Data attributes
 
-| Attribute              | Description                          |
-| ---------------------- | ------------------------------------ |
-| `data-selected`        | Present when the tab is active.      |
-| `data-disabled`        | Present when the tab is disabled.    |
-| `data-orientation`     | Reflects the orientation.            |
+| Attribute          | Description                       |
+| ------------------ | --------------------------------- |
+| `data-selected`    | Present when the tab is active.   |
+| `data-disabled`    | Present when the tab is disabled. |
+| `data-orientation` | Reflects the orientation.         |
 
 ### Tabs.Panel
 
-| Prop          | Type                | Default | Description                                       |
-| ------------- | ------------------- | ------- | ------------------------------------------------- |
-| `value`       | `string \| number`  | --      | Required. The tab value this panel belongs to.    |
-| `keepMounted` | `boolean`           | `false` | Keep the panel mounted in the DOM when hidden.    |
-| `sx`          | `StyleXStyles`      | --      | StyleX styles for consumer overrides.             |
+| Prop          | Type               | Default | Description                                    |
+| ------------- | ------------------ | ------- | ---------------------------------------------- |
+| `value`       | `string \| number` | --      | Required. The tab value this panel belongs to. |
+| `keepMounted` | `boolean`          | `false` | Keep the panel mounted in the DOM when hidden. |
+| `sx`          | `StyleXStyles`     | --      | StyleX styles for consumer overrides.          |
 
 ### Tabs.Indicator
 
-| Prop                    | Type           | Default | Description                                          |
-| ----------------------- | -------------- | ------- | ---------------------------------------------------- |
-| `renderBeforeHydration` | `boolean`      | `false` | Render before React hydrates to reduce SSR flicker.  |
-| `sx`                    | `StyleXStyles` | --      | StyleX styles for consumer overrides.                |
+| Prop                    | Type           | Default | Description                                         |
+| ----------------------- | -------------- | ------- | --------------------------------------------------- |
+| `renderBeforeHydration` | `boolean`      | `false` | Render before React hydrates to reduce SSR flicker. |
+| `sx`                    | `StyleXStyles` | --      | StyleX styles for consumer overrides.               |
 
 #### CSS Variables
 
 The Indicator reads positioning vars from Base UI:
 
-| Variable              | Description                                           |
-| --------------------- | ----------------------------------------------------- |
-| `--active-tab-left`   | Distance of active tab from the left of the list.     |
-| `--active-tab-top`    | Distance of active tab from the top of the list.     |
-| `--active-tab-width`  | Width of the active tab.                              |
-| `--active-tab-height` | Height of the active tab.                             |
+| Variable              | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| `--active-tab-left`   | Distance of active tab from the left of the list. |
+| `--active-tab-top`    | Distance of active tab from the top of the list.  |
+| `--active-tab-width`  | Width of the active tab.                          |
+| `--active-tab-height` | Height of the active tab.                         |
 
 ## When to Use
 

--- a/packages/components/src/tabs/tabs.md
+++ b/packages/components/src/tabs/tabs.md
@@ -1,0 +1,191 @@
+# Tabs
+
+An accessible tab interface that organizes content into selectable panels. Built on [Base UI Tabs](https://base-ui.com/react/components/tabs).
+
+## Anatomy
+
+```tsx
+<Tabs.Root>
+  <Tabs.List>
+    <Tabs.Tab value="a">Tab A</Tabs.Tab>
+    <Tabs.Tab value="b">Tab B</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="a">Panel A</Tabs.Panel>
+  <Tabs.Panel value="b">Panel B</Tabs.Panel>
+</Tabs.Root>
+```
+
+- **Root** -- Container providing state and orientation context.
+- **List** -- The tab strip (`role="tablist"`).
+- **Tab** -- An individual tab button (`role="tab"`, with `aria-controls` / `aria-selected`).
+- **Panel** -- The content panel for a tab (`role="tabpanel"`).
+- **Indicator** -- An optional animated indicator that aligns to the active tab.
+
+## Examples
+
+### Basic
+
+```tsx
+<Tabs.Root defaultValue="overview">
+  <Tabs.List>
+    <Tabs.Tab value="overview">Overview</Tabs.Tab>
+    <Tabs.Tab value="details">Details</Tabs.Tab>
+    <Tabs.Tab value="activity">Activity</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="overview">Overview content</Tabs.Panel>
+  <Tabs.Panel value="details">Details content</Tabs.Panel>
+  <Tabs.Panel value="activity">Activity content</Tabs.Panel>
+</Tabs.Root>
+```
+
+### Vertical
+
+```tsx
+<Tabs.Root orientation="vertical" defaultValue="profile">
+  <Tabs.List>
+    <Tabs.Tab value="profile">Profile</Tabs.Tab>
+    <Tabs.Tab value="account">Account</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="profile">Profile fields</Tabs.Panel>
+  <Tabs.Panel value="account">Account fields</Tabs.Panel>
+</Tabs.Root>
+```
+
+### Manual activation
+
+```tsx
+<Tabs.Root defaultValue="a">
+  <Tabs.List activationMode="manual">
+    <Tabs.Tab value="a">A</Tabs.Tab>
+    <Tabs.Tab value="b">B</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="a">A</Tabs.Panel>
+  <Tabs.Panel value="b">B</Tabs.Panel>
+</Tabs.Root>
+```
+
+### With form content
+
+```tsx
+<Tabs.Root defaultValue="step1">
+  <Tabs.List activationMode="manual">
+    <Tabs.Tab value="step1">Profile</Tabs.Tab>
+    <Tabs.Tab value="step2">Address</Tabs.Tab>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Panel value="step1">
+    <Field.Root>
+      <Field.Label>Name</Field.Label>
+      <Field.Control />
+    </Field.Root>
+  </Tabs.Panel>
+  <Tabs.Panel value="step2">
+    <Field.Root>
+      <Field.Label>City</Field.Label>
+      <Field.Control />
+    </Field.Root>
+  </Tabs.Panel>
+</Tabs.Root>
+```
+
+## Keyboard
+
+| Key                                | Behavior                                                          |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `Tab`                              | Move focus into the tab list.                                     |
+| `ArrowLeft` / `ArrowRight`         | Move focus between tabs (horizontal). RTL-safe.                   |
+| `ArrowUp` / `ArrowDown`            | Move focus between tabs (vertical).                               |
+| `Home` / `End`                     | Move focus to the first/last tab.                                 |
+| `Enter` / `Space`                  | Activate the focused tab (required only with `manual` activation). |
+
+With `activationMode="automatic"` (default) tabs activate on focus. With `activationMode="manual"`, focus and activation are decoupled — preferred when panels contain forms.
+
+## Reduced motion
+
+The indicator transitions are wired through standard CSS transitions; consumers can opt their app into `prefers-reduced-motion` overrides via the global stylesheet:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .basex-tabs-indicator {
+    transition-duration: 0ms !important;
+  }
+}
+```
+
+## API Reference
+
+### Tabs.Root
+
+| Prop            | Type                                       | Default        | Description                                  |
+| --------------- | ------------------------------------------ | -------------- | -------------------------------------------- |
+| `value`         | `string \| number \| null`                 | --             | The active tab value (controlled).           |
+| `defaultValue`  | `string \| number \| null`                 | `0`            | The initially active tab (uncontrolled).     |
+| `onValueChange` | `(value, eventDetails) => void`            | --             | Callback when the active tab changes.        |
+| `orientation`   | `'horizontal' \| 'vertical'`               | `'horizontal'` | Layout flow direction.                       |
+| `sx`            | `StyleXStyles`                             | --             | StyleX styles for consumer overrides.        |
+
+### Tabs.List
+
+| Prop             | Type                          | Default       | Description                                                            |
+| ---------------- | ----------------------------- | ------------- | ---------------------------------------------------------------------- |
+| `activationMode` | `'automatic' \| 'manual'`     | `'automatic'` | Whether tabs activate on focus (`automatic`) or only on Enter/Space.   |
+| `loopFocus`      | `boolean`                     | `true`        | Whether arrow-key focus loops at the ends of the list.                 |
+| `sx`             | `StyleXStyles`                | --            | StyleX styles for consumer overrides.                                  |
+
+### Tabs.Tab
+
+| Prop       | Type                | Default | Description                              |
+| ---------- | ------------------- | ------- | ---------------------------------------- |
+| `value`    | `string \| number`  | --      | Required. Identifies this tab.           |
+| `disabled` | `boolean`           | `false` | Whether the tab is disabled.             |
+| `sx`       | `StyleXStyles`      | --      | StyleX styles for consumer overrides.    |
+
+#### Data attributes
+
+| Attribute              | Description                          |
+| ---------------------- | ------------------------------------ |
+| `data-selected`        | Present when the tab is active.      |
+| `data-disabled`        | Present when the tab is disabled.    |
+| `data-orientation`     | Reflects the orientation.            |
+
+### Tabs.Panel
+
+| Prop          | Type                | Default | Description                                       |
+| ------------- | ------------------- | ------- | ------------------------------------------------- |
+| `value`       | `string \| number`  | --      | Required. The tab value this panel belongs to.    |
+| `keepMounted` | `boolean`           | `false` | Keep the panel mounted in the DOM when hidden.    |
+| `sx`          | `StyleXStyles`      | --      | StyleX styles for consumer overrides.             |
+
+### Tabs.Indicator
+
+| Prop                    | Type           | Default | Description                                          |
+| ----------------------- | -------------- | ------- | ---------------------------------------------------- |
+| `renderBeforeHydration` | `boolean`      | `false` | Render before React hydrates to reduce SSR flicker.  |
+| `sx`                    | `StyleXStyles` | --      | StyleX styles for consumer overrides.                |
+
+#### CSS Variables
+
+The Indicator reads positioning vars from Base UI:
+
+| Variable              | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| `--active-tab-left`   | Distance of active tab from the left of the list.     |
+| `--active-tab-top`    | Distance of active tab from the top of the list.     |
+| `--active-tab-width`  | Width of the active tab.                              |
+| `--active-tab-height` | Height of the active tab.                             |
+
+## When to Use
+
+- Switching between sibling content panels at the same level of hierarchy.
+- Settings or preference sections grouped vertically.
+- Surface-level views of an entity (Overview / Activity / Comments).
+
+## When NOT to Use
+
+- **Sequential steps that must be completed in order** -- use a stepper.
+- **Site navigation between pages** -- use NavigationMenu.
+- **Many sections or long labels** -- use Accordion or a sidebar.

--- a/packages/components/src/tabs/tabs.test.ts
+++ b/packages/components/src/tabs/tabs.test.ts
@@ -1,0 +1,43 @@
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@stylexjs/stylex', () => {
+  const m = {
+    create: (s: Record<string, unknown>) => s,
+    props: () => ({ className: '' }),
+    defineVars: (v: Record<string, unknown>) => v,
+    createTheme: () => ({}),
+  };
+  return { default: m, ...m };
+});
+vi.mock('@basex-ui/tokens', () => ({
+  tokens: new Proxy({}, { get: (_, p) => `var(--${String(p)})` }),
+}));
+vi.mock('@basex-ui/styles', () => ({
+  focusRing: {},
+  capitalize: {},
+}));
+
+import { Tabs } from './index';
+
+describe('Tabs', () => {
+  it('exports all compound parts', () => {
+    expect(Tabs.Root).toBeDefined();
+    expect(Tabs.List).toBeDefined();
+    expect(Tabs.Tab).toBeDefined();
+    expect(Tabs.Panel).toBeDefined();
+    expect(Tabs.Indicator).toBeDefined();
+  });
+
+  it('sets displayName on all parts', () => {
+    expect(Tabs.Root.displayName).toBe('Tabs.Root');
+    expect(Tabs.List.displayName).toBe('Tabs.List');
+    expect(Tabs.Tab.displayName).toBe('Tabs.Tab');
+    expect(Tabs.Panel.displayName).toBe('Tabs.Panel');
+    expect(Tabs.Indicator.displayName).toBe('Tabs.Indicator');
+  });
+
+  it('does not expose unexpected parts', () => {
+    const expectedParts = ['Root', 'List', 'Tab', 'Panel', 'Indicator'];
+    expect(Object.keys(Tabs).sort()).toEqual(expectedParts.sort());
+  });
+});

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -122,13 +122,17 @@ const styles = stylex.create({
 // --- Types ---
 export type TabsActivationMode = 'automatic' | 'manual';
 
-export interface TabsRootProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Root>, 'className'> {
+export interface TabsRootProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Root>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsListProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.List>, 'className'> {
+export interface TabsListProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.List>,
+  'className'
+> {
   sx?: StyleXStyles;
   /**
    * Activation mode for the tabs.
@@ -138,18 +142,24 @@ export interface TabsListProps
   activationMode?: TabsActivationMode;
 }
 
-export interface TabsTabProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>, 'className'> {
+export interface TabsTabProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsPanelProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>, 'className'> {
+export interface TabsPanelProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsIndicatorProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>, 'className'> {
+export interface TabsIndicatorProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -56,9 +56,11 @@ const styles = stylex.create({
       default: tokens.colorTextMuted,
       ':hover': tokens.colorText,
     },
+    // Inactive tabs carry a faint fill so each trigger reads as a
+    // clickable chip (Spotify-style nav). Hover bumps one notch.
     backgroundColor: {
-      default: 'transparent',
-      ':hover': tokens.colorMuted,
+      default: tokens.colorMuted,
+      ':hover': tokens.colorBorderMuted,
     },
     borderWidth: 0,
     borderRadius: tokens.radiusSm,

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -6,6 +6,12 @@ import { forwardRef } from 'react';
 import type { StyleXStyles } from '@stylexjs/stylex';
 
 // --- Styles ---
+//
+// Filled-block active state, squared corners (radiusSm = 0).
+// Active tab: solid fill in the foreground neutral (theme-aware) with the
+// inverse text color. Inactive tabs: bare muted text on the surrounding
+// surface, with a subtle hover tint. The result reads like Spotify's nav:
+// the active selection is unmistakable, and inactive tabs stay quiet.
 const styles = stylex.create({
   root: {
     display: 'flex',
@@ -27,18 +33,11 @@ const styles = stylex.create({
     gap: tokens.space1,
     padding: 0,
     margin: 0,
-    borderBottomWidth: tokens.borderWidthDefault,
-    borderBottomStyle: 'solid',
-    borderBottomColor: tokens.colorBorderMuted,
   },
 
   listVertical: {
     flexDirection: 'column',
     alignItems: 'stretch',
-    borderBottomWidth: 0,
-    borderInlineEndWidth: tokens.borderWidthDefault,
-    borderInlineEndStyle: 'solid',
-    borderInlineEndColor: tokens.colorBorderMuted,
   },
 
   tab: {
@@ -53,13 +52,16 @@ const styles = stylex.create({
     fontWeight: tokens.fontWeightMedium,
     fontSize: tokens.fontSizeSm,
     lineHeight: tokens.lineHeightTight,
-    color: tokens.colorTextMuted,
+    color: {
+      default: tokens.colorTextMuted,
+      ':hover': tokens.colorText,
+    },
     backgroundColor: {
       default: 'transparent',
       ':hover': tokens.colorMuted,
     },
     borderWidth: 0,
-    borderRadius: tokens.radiusMd,
+    borderRadius: tokens.radiusSm,
     cursor: 'pointer',
     userSelect: 'none',
     whiteSpace: 'nowrap',
@@ -68,16 +70,24 @@ const styles = stylex.create({
     transitionTimingFunction: tokens.motionEaseOut,
   },
 
+  // Active: filled block. Override hover so the active tab keeps its strong
+  // fill regardless of pointer state — the active state should never weaken.
   tabActive: {
-    color: tokens.colorText,
-    backgroundColor: 'transparent',
+    color: {
+      default: tokens.colorTextInverse,
+      ':hover': tokens.colorTextInverse,
+    },
+    backgroundColor: {
+      default: tokens.colorText,
+      ':hover': tokens.colorText,
+    },
   },
 
   tabDisabled: {
     color: tokens.colorTextMuted,
-    borderColor: tokens.colorBorderMuted,
-    cursor: 'not-allowed',
     backgroundColor: 'transparent',
+    cursor: 'not-allowed',
+    opacity: 0.5,
   },
 
   panel: {
@@ -88,51 +98,25 @@ const styles = stylex.create({
     lineHeight: tokens.lineHeightNormal,
   },
 
+  // Indicator: kept as a part of the public API for consumers, but visually
+  // a no-op — the active state is expressed through tabActive's filled block.
+  // Rendering it as `display: none` keeps `<Tabs.Indicator />` valid in JSX
+  // without painting a competing underline.
   indicator: {
-    position: 'absolute',
-    // Default: horizontal underline aligned to active tab
-    insetBlockEnd: 0,
-    insetInlineStart: 0,
-    height: '2px',
-    width: 'var(--active-tab-width, 0px)',
-    transform: 'translateX(var(--active-tab-left, 0px))',
-    backgroundColor: tokens.colorText,
-    borderRadius: tokens.radiusFull,
-    transitionProperty: 'transform, width, height, top',
-    transitionDuration: tokens.motionDurationNormal,
-    transitionTimingFunction: tokens.motionEaseInOut,
-    pointerEvents: 'none',
-  },
-
-  indicatorVertical: {
-    insetBlockStart: 0,
-    insetInlineEnd: 0,
-    insetInlineStart: 'auto',
-    insetBlockEnd: 'auto',
-    width: '2px',
-    height: 'var(--active-tab-height, 0px)',
-    transform: 'translateY(var(--active-tab-top, 0px))',
-  },
-
-  reducedMotion: {
-    transitionDuration: '0ms',
+    display: 'none',
   },
 });
 
 // --- Types ---
 export type TabsActivationMode = 'automatic' | 'manual';
 
-export interface TabsRootProps extends Omit<
-  React.ComponentPropsWithoutRef<typeof BaseTabs.Root>,
-  'className'
-> {
+export interface TabsRootProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Root>, 'className'> {
   sx?: StyleXStyles;
 }
 
-export interface TabsListProps extends Omit<
-  React.ComponentPropsWithoutRef<typeof BaseTabs.List>,
-  'className'
-> {
+export interface TabsListProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.List>, 'className'> {
   sx?: StyleXStyles;
   /**
    * Activation mode for the tabs.
@@ -142,24 +126,18 @@ export interface TabsListProps extends Omit<
   activationMode?: TabsActivationMode;
 }
 
-export interface TabsTabProps extends Omit<
-  React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>,
-  'className'
-> {
+export interface TabsTabProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>, 'className'> {
   sx?: StyleXStyles;
 }
 
-export interface TabsPanelProps extends Omit<
-  React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>,
-  'className'
-> {
+export interface TabsPanelProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>, 'className'> {
   sx?: StyleXStyles;
 }
 
-export interface TabsIndicatorProps extends Omit<
-  React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>,
-  'className'
-> {
+export interface TabsIndicatorProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>, 'className'> {
   sx?: StyleXStyles;
 }
 
@@ -231,14 +209,8 @@ const Indicator = forwardRef<HTMLSpanElement, TabsIndicatorProps>(({ sx, ...prop
   <BaseTabs.Indicator
     ref={ref}
     {...props}
-    className={(state) =>
-      `basex-tabs-indicator ${
-        stylex.props(
-          styles.indicator,
-          state.orientation === 'vertical' && styles.indicatorVertical,
-          sx,
-        ).className ?? ''
-      }`
+    className={() =>
+      `basex-tabs-indicator ${stylex.props(styles.indicator, sx).className ?? ''}`
     }
   />
 ));

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -112,13 +112,17 @@ const styles = stylex.create({
 // --- Types ---
 export type TabsActivationMode = 'automatic' | 'manual';
 
-export interface TabsRootProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Root>, 'className'> {
+export interface TabsRootProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Root>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsListProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.List>, 'className'> {
+export interface TabsListProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.List>,
+  'className'
+> {
   sx?: StyleXStyles;
   /**
    * Activation mode for the tabs.
@@ -128,18 +132,24 @@ export interface TabsListProps
   activationMode?: TabsActivationMode;
 }
 
-export interface TabsTabProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>, 'className'> {
+export interface TabsTabProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsPanelProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>, 'className'> {
+export interface TabsPanelProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
-export interface TabsIndicatorProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>, 'className'> {
+export interface TabsIndicatorProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>,
+  'className'
+> {
   sx?: StyleXStyles;
 }
 
@@ -211,9 +221,7 @@ const Indicator = forwardRef<HTMLSpanElement, TabsIndicatorProps>(({ sx, ...prop
   <BaseTabs.Indicator
     ref={ref}
     {...props}
-    className={() =>
-      `basex-tabs-indicator ${stylex.props(styles.indicator, sx).className ?? ''}`
-    }
+    className={() => `basex-tabs-indicator ${stylex.props(styles.indicator, sx).className ?? ''}`}
   />
 ));
 Indicator.displayName = 'Tabs.Indicator';

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -1,0 +1,244 @@
+import { Tabs as BaseTabs } from '@base-ui/react/tabs';
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { focusRing } from '@basex-ui/styles';
+import { forwardRef } from 'react';
+import type { StyleXStyles } from '@stylexjs/stylex';
+
+// --- Styles ---
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.space3,
+    fontFamily: tokens.fontFamilySans,
+  },
+
+  rootVertical: {
+    flexDirection: 'row',
+    gap: tokens.space4,
+  },
+
+  list: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: tokens.space1,
+    padding: 0,
+    margin: 0,
+    borderBottomWidth: tokens.borderWidthDefault,
+    borderBottomStyle: 'solid',
+    borderBottomColor: tokens.colorBorderMuted,
+  },
+
+  listVertical: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    borderBottomWidth: 0,
+    borderInlineEndWidth: tokens.borderWidthDefault,
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: tokens.colorBorderMuted,
+  },
+
+  tab: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: tokens.space1h,
+    paddingBlock: tokens.space2,
+    paddingInline: tokens.space3,
+    fontFamily: tokens.fontFamilySans,
+    fontWeight: tokens.fontWeightMedium,
+    fontSize: tokens.fontSizeSm,
+    lineHeight: tokens.lineHeightTight,
+    color: tokens.colorTextMuted,
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': tokens.colorMuted,
+    },
+    borderWidth: 0,
+    borderRadius: tokens.radiusMd,
+    cursor: 'pointer',
+    userSelect: 'none',
+    whiteSpace: 'nowrap',
+    transitionProperty: 'background-color, color',
+    transitionDuration: tokens.motionDurationFast,
+    transitionTimingFunction: tokens.motionEaseOut,
+  },
+
+  tabActive: {
+    color: tokens.colorText,
+    backgroundColor: 'transparent',
+  },
+
+  tabDisabled: {
+    color: tokens.colorTextMuted,
+    borderColor: tokens.colorBorderMuted,
+    cursor: 'not-allowed',
+    backgroundColor: 'transparent',
+  },
+
+  panel: {
+    outline: 'none',
+    color: tokens.colorText,
+    fontFamily: tokens.fontFamilySans,
+    fontSize: tokens.fontSizeSm,
+    lineHeight: tokens.lineHeightNormal,
+  },
+
+  indicator: {
+    position: 'absolute',
+    // Default: horizontal underline aligned to active tab
+    insetBlockEnd: 0,
+    insetInlineStart: 0,
+    height: '2px',
+    width: 'var(--active-tab-width, 0px)',
+    transform: 'translateX(var(--active-tab-left, 0px))',
+    backgroundColor: tokens.colorText,
+    borderRadius: tokens.radiusFull,
+    transitionProperty: 'transform, width, height, top',
+    transitionDuration: tokens.motionDurationNormal,
+    transitionTimingFunction: tokens.motionEaseInOut,
+    pointerEvents: 'none',
+  },
+
+  indicatorVertical: {
+    insetBlockStart: 0,
+    insetInlineEnd: 0,
+    insetInlineStart: 'auto',
+    insetBlockEnd: 'auto',
+    width: '2px',
+    height: 'var(--active-tab-height, 0px)',
+    transform: 'translateY(var(--active-tab-top, 0px))',
+  },
+
+  reducedMotion: {
+    transitionDuration: '0ms',
+  },
+});
+
+// --- Types ---
+export type TabsActivationMode = 'automatic' | 'manual';
+
+export interface TabsRootProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Root>, 'className'> {
+  sx?: StyleXStyles;
+}
+
+export interface TabsListProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.List>, 'className'> {
+  sx?: StyleXStyles;
+  /**
+   * Activation mode for the tabs.
+   * - `'automatic'` (default): tab activates as it receives keyboard focus.
+   * - `'manual'`: focus moves with arrow keys, but activation requires Enter/Space.
+   */
+  activationMode?: TabsActivationMode;
+}
+
+export interface TabsTabProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>, 'className'> {
+  sx?: StyleXStyles;
+}
+
+export interface TabsPanelProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>, 'className'> {
+  sx?: StyleXStyles;
+}
+
+export interface TabsIndicatorProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof BaseTabs.Indicator>, 'className'> {
+  sx?: StyleXStyles;
+}
+
+// --- Components ---
+
+const Root = forwardRef<HTMLDivElement, TabsRootProps>(({ sx, orientation, ...props }, ref) => (
+  <BaseTabs.Root
+    ref={ref}
+    orientation={orientation}
+    {...props}
+    className={
+      stylex.props(styles.root, orientation === 'vertical' && styles.rootVertical, sx).className ??
+      ''
+    }
+  />
+));
+Root.displayName = 'Tabs.Root';
+
+const List = forwardRef<HTMLDivElement, TabsListProps>(
+  ({ sx, activationMode = 'automatic', activateOnFocus, ...props }, ref) => {
+    // Map our user-facing prop to Base UI's `activateOnFocus`.
+    // If the consumer passes `activateOnFocus` directly, honor it; otherwise derive from activationMode.
+    const resolvedActivateOnFocus =
+      activateOnFocus !== undefined ? activateOnFocus : activationMode === 'automatic';
+    return (
+      <BaseTabs.List
+        ref={ref}
+        activateOnFocus={resolvedActivateOnFocus}
+        {...props}
+        className={(state) =>
+          `basex-tabs-list ${
+            stylex.props(styles.list, state.orientation === 'vertical' && styles.listVertical, sx)
+              .className ?? ''
+          }`
+        }
+      />
+    );
+  },
+);
+List.displayName = 'Tabs.List';
+
+const Tab = forwardRef<HTMLButtonElement, TabsTabProps>(({ sx, ...props }, ref) => (
+  <BaseTabs.Tab
+    ref={ref}
+    {...props}
+    className={(state) =>
+      stylex.props(
+        styles.tab,
+        focusRing,
+        state.active && styles.tabActive,
+        state.disabled && styles.tabDisabled,
+        sx,
+      ).className ?? ''
+    }
+  />
+));
+Tab.displayName = 'Tabs.Tab';
+
+const Panel = forwardRef<HTMLDivElement, TabsPanelProps>(({ sx, ...props }, ref) => (
+  <BaseTabs.Panel
+    ref={ref}
+    {...props}
+    className={() => `basex-tabs-panel ${stylex.props(styles.panel, sx).className ?? ''}`}
+  />
+));
+Panel.displayName = 'Tabs.Panel';
+
+const Indicator = forwardRef<HTMLSpanElement, TabsIndicatorProps>(({ sx, ...props }, ref) => (
+  <BaseTabs.Indicator
+    ref={ref}
+    {...props}
+    className={(state) =>
+      `basex-tabs-indicator ${
+        stylex.props(
+          styles.indicator,
+          state.orientation === 'vertical' && styles.indicatorVertical,
+          sx,
+        ).className ?? ''
+      }`
+    }
+  />
+));
+Indicator.displayName = 'Tabs.Indicator';
+
+// --- Public API ---
+export const Tabs = {
+  Root,
+  List,
+  Tab,
+  Panel,
+  Indicator,
+};

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     'src/preview-card/index.ts',
     'src/progress/index.ts',
     'src/radio/index.ts',
+    'src/tabs/index.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/intelligence/intents.json
+++ b/packages/intelligence/intents.json
@@ -534,6 +534,34 @@
       "signals": ["preference", "settings choice", "plan selection", "tier", "mode selector"],
       "reasoning": "Radio groups work well for preference or settings where users pick exactly one option from a small set.",
       "composition": "<Radio.Group defaultValue=\"standard\">\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"standard\"><Radio.Indicator /></Radio.Root>\n    Standard\n  </label>\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"express\"><Radio.Indicator /></Radio.Root>\n    Express\n  </label>\n</Radio.Group>"
+    },
+    {
+      "intent": "tabbed-content",
+      "component": "Tabs",
+      "signals": [
+        "tabs",
+        "tabbed",
+        "tab interface",
+        "switch between views",
+        "tabbed sections",
+        "panel switcher"
+      ],
+      "reasoning": "Tabs is the canonical component for switching between mutually exclusive content panels at the same level of hierarchy.",
+      "composition": "<Tabs.Root defaultValue=\"overview\">\n  <Tabs.List>\n    <Tabs.Tab value=\"overview\">Overview</Tabs.Tab>\n    <Tabs.Tab value=\"details\">Details</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"overview\">Overview content</Tabs.Panel>\n  <Tabs.Panel value=\"details\">Details content</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "intent": "settings-sections",
+      "component": "Tabs",
+      "signals": ["settings tabs", "preferences tabs", "vertical tabs", "side tabs"],
+      "reasoning": "Vertical Tabs work well for settings UIs where users move between configuration groups.",
+      "composition": "<Tabs.Root orientation=\"vertical\" defaultValue=\"profile\">\n  <Tabs.List>\n    <Tabs.Tab value=\"profile\">Profile</Tabs.Tab>\n    <Tabs.Tab value=\"account\">Account</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"profile\">Profile fields</Tabs.Panel>\n  <Tabs.Panel value=\"account\">Account fields</Tabs.Panel>\n</Tabs.Root>"
+    },
+    {
+      "intent": "form-with-tabs",
+      "component": "Tabs",
+      "signals": ["multi-step form", "tabbed form", "form sections"],
+      "reasoning": "Use manual activation when tab content includes form controls, so screen readers don't trigger panel changes during arrow-key navigation.",
+      "composition": "<Tabs.Root defaultValue=\"step1\">\n  <Tabs.List activationMode=\"manual\">\n    <Tabs.Tab value=\"step1\">Step 1</Tabs.Tab>\n    <Tabs.Tab value=\"step2\">Step 2</Tabs.Tab>\n    <Tabs.Indicator />\n  </Tabs.List>\n  <Tabs.Panel value=\"step1\">{/* form fields */}</Tabs.Panel>\n  <Tabs.Panel value=\"step2\">{/* form fields */}</Tabs.Panel>\n</Tabs.Root>"
     }
   ],
   "antiPatterns": [
@@ -956,6 +984,24 @@
       "scenario": "Binary on/off toggle",
       "reasoning": "Use Switch for a single boolean toggle. Radio is for choosing between labeled options.",
       "alternative": "Switch"
+    },
+    {
+      "component": "Tabs",
+      "scenario": "Sequential steps that must be completed in order",
+      "reasoning": "Tabs imply free navigation between siblings. For ordered flows, use a stepper or wizard pattern.",
+      "alternative": "Custom stepper"
+    },
+    {
+      "component": "Tabs",
+      "scenario": "Site-wide navigation between pages",
+      "reasoning": "Tabs are for content within a single view. Use NavigationMenu for top-level site nav.",
+      "alternative": "NavigationMenu"
+    },
+    {
+      "component": "Tabs",
+      "scenario": "Many sections (more than ~7) or long labels that wrap",
+      "reasoning": "Tab lists work best with a small number of short labels. Use Accordion or a sidebar nav for larger sets.",
+      "alternative": "Accordion"
     }
   ]
 }

--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -13,7 +13,8 @@ describe('listComponents', () => {
     const names = list.map((c) => c.name);
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
-    expect(list).toHaveLength(24);
+    expect(names).toContain('Tabs');
+    expect(list).toHaveLength(25);
   });
 });
 

--- a/packages/mcp-server/src/data.ts
+++ b/packages/mcp-server/src/data.ts
@@ -38,6 +38,7 @@ import popoverManifest from '../../components/src/popover/manifest.json';
 import previewCardManifest from '../../components/src/preview-card/manifest.json';
 import progressManifest from '../../components/src/progress/manifest.json';
 import radioManifest from '../../components/src/radio/manifest.json';
+import tabsManifest from '../../components/src/tabs/manifest.json';
 
 export type ComponentManifest =
   | typeof buttonManifest
@@ -63,7 +64,8 @@ export type ComponentManifest =
   | typeof popoverManifest
   | typeof previewCardManifest
   | typeof progressManifest
-  | typeof radioManifest;
+  | typeof radioManifest
+  | typeof tabsManifest;
 
 const components = new Map<string, ComponentManifest>([
   ['button', buttonManifest],
@@ -90,6 +92,7 @@ const components = new Map<string, ComponentManifest>([
   ['preview-card', previewCardManifest],
   ['progress', progressManifest],
   ['radio', radioManifest],
+  ['tabs', tabsManifest],
 ] as [string, ComponentManifest][]);
 
 // ---------------------------------------------------------------------------
@@ -262,6 +265,10 @@ export function getComponentSetup(name: string): ComponentSetup | null {
       { interaction: 'indeterminate animation', preset: 'Move' },
     ],
     radio: [{ interaction: 'indicator appear/disappear', preset: 'State' }],
+    tabs: [
+      { interaction: 'tab hover/focus color', preset: 'State' },
+      { interaction: 'indicator slide to active tab', preset: 'Move' },
+    ],
   };
 
   return {


### PR DESCRIPTION
## Summary

Adds **Tabs** to Base-X UI — Radix-style headless component built on Base UI Tabs with StyleX styling that matches the Navigation Menu / Menubar trigger family.

## Anatomy

```
<Tabs.Root>
  <Tabs.List>
    <Tabs.Tab value="..." />
    <Tabs.Indicator />
  </Tabs.List>
  <Tabs.Panel value="..." />
</Tabs.Root>
```

`Root, List, Tab, Panel, Indicator`. Full ARIA wiring (`role="tablist" / "tab" / "tabpanel"`, `aria-controls`, `aria-selected`) inherited from Base UI.

## Tokens used (Nav Menu / Menubar parity)

`colorText`, `colorTextMuted`, `colorMuted`, `colorBorderMuted`, `colorFocusRing`,
`space1`, `space1h`, `space2`, `space3`, `space4`,
`fontFamilySans`, `fontSizeSm`, `fontWeightMedium`, `lineHeightTight`, `lineHeightNormal`,
`radiusMd`, `radiusFull`, `borderWidthDefault`,
`motionDurationFast`, `motionDurationNormal`, `motionEaseOut`, `motionEaseInOut`.

Tab trigger styling deliberately mirrors `NavigationMenu.Trigger` (same paddings, font scale, hover background, focus ring) so the components feel like a family. No new tokens introduced.

## Keyboard

| Key | Behavior |
| --- | --- |
| Tab | Move focus into the list |
| ArrowLeft / ArrowRight | Move between tabs (horizontal, RTL-safe) |
| ArrowUp / ArrowDown | Move between tabs (vertical) |
| Home / End | Jump to first / last tab |
| Enter / Space | Activate focused tab (required only with manual activation) |

## Activation mode

Default is **`automatic`** (tab activates on focus) — matches the WAI-ARIA "Tabs with Automatic Activation" pattern most users expect on the web. Pass `activationMode="manual"` on `Tabs.List` when panels contain forms or other controls so arrow-key navigation doesn't blow away unsaved input. Internally maps to Base UI's `activateOnFocus`.

## Indicator decision

Optional `Tabs.Indicator` reads Base UI's CSS vars (`--active-tab-left/-top/-width/-height`) and slides via CSS transitions (Move preset: 200ms ease-in-out). On vertical orientation it flips to the inline-end edge. A `prefers-reduced-motion: reduce` rule in `apps/docs/src/index.css` zeroes its transition duration. No new global animation CSS is required for tabs themselves.

## What needs review

- Underline-style indicator vs. pill-style — went with a 2px underline that mirrors the muted bottom-border of `Tabs.List` and respects orientation; happy to swap to a filled pill.
- Vertical default gap (`space4`) and the inline-end border on `Tabs.List` — wanted to echo the menubar's enclosing-line feel without adding background.
- `activationMode` is implemented as a pass-through on `Tabs.List` (the Base UI seam) rather than `Tabs.Root` — flag if you'd rather have it on Root.

## Test plan

- [ ] `pnpm install && pnpm -w build` (passes locally)
- [ ] `pnpm -w test` (53 tests passing, including new Tabs tests + updated mcp-server count)
- [ ] `pnpm -w lint` (no new errors; one pre-existing warning in `App.tsx` unrelated)
- [ ] Visit `/components/tabs` in the docs app and verify basic, vertical, manual activation, with form content, and controlled demos
- [ ] Verify keyboard nav (arrows, Home/End) and that focus ring matches Navigation Menu / Menubar

🤖 Generated with [Claude Code](https://claude.com/claude-code)