### PR TITLE
feat: add Slider component

### DIFF
--- a/apps/docs/src/content/api-docs.ts
+++ b/apps/docs/src/content/api-docs.ts
@@ -22,6 +22,7 @@ import popover from '../../../../packages/components/src/popover/popover.md?raw'
 import previewCard from '../../../../packages/components/src/preview-card/preview-card.md?raw';
 import progress from '../../../../packages/components/src/progress/progress.md?raw';
 import radio from '../../../../packages/components/src/radio/radio.md?raw';
+import slider from '../../../../packages/components/src/slider/slider.md?raw';
 
 export const apiDocs: Record<string, string> = {
   accordion,
@@ -48,4 +49,5 @@ export const apiDocs: Record<string, string> = {
   'preview-card': previewCard,
   progress,
   radio,
+  slider,
 };

--- a/apps/docs/src/pages/SliderPage.tsx
+++ b/apps/docs/src/pages/SliderPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { tokens } from '@basex-ui/tokens';
 import { Slider, Field } from '@basex-ui/components';
@@ -26,8 +25,6 @@ const pageStyles = stylex.create({
 });
 
 export function SliderPage() {
-  const [value, setValue] = useState<number>(40);
-
   return (
     <>
       <Preview
@@ -46,37 +43,6 @@ export function SliderPage() {
       >
         <Slider.Root defaultValue={40}>
           <Slider.Label>Volume</Slider.Label>
-          <Slider.Control>
-            <Slider.Track>
-              <Slider.Indicator />
-              <Slider.Thumb />
-            </Slider.Track>
-          </Slider.Control>
-        </Slider.Root>
-      </Preview>
-
-      <Preview
-        title="Controlled with value"
-        description="Render the live value alongside the slider."
-        constrained
-        code={`const [value, setValue] = useState(40);
-
-<Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>
-  <Slider.Label>Brightness</Slider.Label>
-  <Slider.Value />
-  <Slider.Control>
-    <Slider.Track>
-      <Slider.Indicator />
-      <Slider.Thumb />
-    </Slider.Track>
-  </Slider.Control>
-</Slider.Root>`}
-      >
-        <Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>
-          <div {...stylex.props(pageStyles.row)}>
-            <Slider.Label>Brightness</Slider.Label>
-            <Slider.Value />
-          </div>
           <Slider.Control>
             <Slider.Track>
               <Slider.Indicator />

--- a/apps/docs/src/pages/SliderPage.tsx
+++ b/apps/docs/src/pages/SliderPage.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { Slider, Field } from '@basex-ui/components';
+import { Preview } from '../components/Preview';
+
+const pageStyles = stylex.create({
+  stack: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.space4,
+    width: '100%',
+  },
+  row: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: tokens.space3,
+  },
+  verticalRow: {
+    display: 'flex',
+    gap: tokens.space6,
+    alignItems: 'flex-end',
+    height: '180px',
+  },
+});
+
+export function SliderPage() {
+  const [value, setValue] = useState<number>(40);
+
+  return (
+    <>
+      <Preview
+        title="Basic"
+        description="A single-value slider with a label."
+        constrained
+        code={`<Slider.Root defaultValue={40}>
+  <Slider.Label>Volume</Slider.Label>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>`}
+      >
+        <Slider.Root defaultValue={40}>
+          <Slider.Label>Volume</Slider.Label>
+          <Slider.Control>
+            <Slider.Track>
+              <Slider.Indicator />
+              <Slider.Thumb />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </Preview>
+
+      <Preview
+        title="Controlled with value"
+        description="Render the live value alongside the slider."
+        constrained
+        code={`const [value, setValue] = useState(40);
+
+<Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>
+  <Slider.Label>Brightness</Slider.Label>
+  <Slider.Value />
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>`}
+      >
+        <Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>
+          <div {...stylex.props(pageStyles.row)}>
+            <Slider.Label>Brightness</Slider.Label>
+            <Slider.Value />
+          </div>
+          <Slider.Control>
+            <Slider.Track>
+              <Slider.Indicator />
+              <Slider.Thumb />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </Preview>
+
+      <Preview
+        title="Range (multi-value)"
+        description="Two thumbs for picking a min/max bracket."
+        constrained
+        code={`<Slider.Root defaultValue={[25, 75]} minStepsBetweenValues={1}>
+  <Slider.Label>Price range</Slider.Label>
+  <Slider.Value />
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb index={0} />
+      <Slider.Thumb index={1} />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>`}
+      >
+        <Slider.Root defaultValue={[25, 75]} minStepsBetweenValues={1}>
+          <div {...stylex.props(pageStyles.row)}>
+            <Slider.Label>Price range</Slider.Label>
+            <Slider.Value />
+          </div>
+          <Slider.Control>
+            <Slider.Track>
+              <Slider.Indicator />
+              <Slider.Thumb index={0} />
+              <Slider.Thumb index={1} />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </Preview>
+
+      <Preview
+        title="Vertical"
+        description="Fader-style vertical orientation."
+        constrained
+        code={`<Slider.Root orientation="vertical" defaultValue={60}>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>`}
+      >
+        <div {...stylex.props(pageStyles.verticalRow)}>
+          <Slider.Root orientation="vertical" defaultValue={30}>
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+          <Slider.Root orientation="vertical" defaultValue={60}>
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+          <Slider.Root orientation="vertical" defaultValue={85}>
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+        </div>
+      </Preview>
+
+      <Preview
+        title="Inside a Field"
+        description="Composes with Field for label, description, and validation messaging."
+        constrained
+        code={`<Field.Root>
+  <Field.Label>Quality</Field.Label>
+  <Slider.Root defaultValue={50}>
+    <Slider.Control>
+      <Slider.Track>
+        <Slider.Indicator />
+        <Slider.Thumb />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+  <Field.Description>Lower values save bandwidth.</Field.Description>
+</Field.Root>`}
+      >
+        <Field.Root>
+          <Field.Label>Quality</Field.Label>
+          <Slider.Root defaultValue={50}>
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Indicator />
+                <Slider.Thumb />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+          <Field.Description>Lower values save bandwidth.</Field.Description>
+        </Field.Root>
+      </Preview>
+
+      <Preview
+        title="Disabled"
+        description="Non-interactive state using muted tokens (no opacity)."
+        constrained
+        code={`<Slider.Root defaultValue={30} disabled>
+  <Slider.Label>Locked</Slider.Label>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>`}
+      >
+        <Slider.Root defaultValue={30} disabled>
+          <Slider.Label>Locked</Slider.Label>
+          <Slider.Control>
+            <Slider.Track>
+              <Slider.Indicator />
+              <Slider.Thumb />
+            </Slider.Track>
+          </Slider.Control>
+        </Slider.Root>
+      </Preview>
+    </>
+  );
+}

--- a/apps/docs/src/registry.ts
+++ b/apps/docs/src/registry.ts
@@ -24,6 +24,7 @@ import { PopoverPage } from './pages/PopoverPage';
 import { PreviewCardPage } from './pages/PreviewCardPage';
 import { ProgressPage } from './pages/ProgressPage';
 import { RadioPage } from './pages/RadioPage';
+import { SliderPage } from './pages/SliderPage';
 
 export interface PageEntry {
   id: string;
@@ -262,6 +263,14 @@ export const pages: PageEntry[] = [
     path: '/components/radio',
     section: 'components',
     component: RadioPage,
+  },
+  {
+    id: 'slider',
+    label: 'Slider',
+    description: 'A range input for picking a single value or a range from a continuous scale.',
+    path: '/components/slider',
+    section: 'components',
+    component: SliderPage,
   },
 
   // Intelligence section

--- a/docs/plans/component-roadmap.md
+++ b/docs/plans/component-roadmap.md
@@ -36,7 +36,7 @@
 | 26  | Scroll Area     | `ScrollArea`     | **Next** |              |
 | 27  | Select          | `Select`         | —        |              |
 | 28  | Separator       | `Separator`      | —        |              |
-| 29  | Slider          | `Slider`         | —        |              |
+| 29  | Slider          | `Slider`         | Done     |              |
 | 30  | Switch          | `Switch`         | —        |              |
 | 31  | Tabs            | `Tabs`           | —        |              |
 | 32  | Toast           | `Toast`          | —        |              |
@@ -47,7 +47,7 @@
 
 ## Progress
 
-- **Done**: 25 / 36
+- **Done**: 26 / 36
 - **Next**: Scroll Area
 
 ## How to Use This File

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -120,6 +120,10 @@
     "./radio": {
       "types": "./dist/radio/index.d.ts",
       "import": "./dist/radio/index.js"
+    },
+    "./slider": {
+      "types": "./dist/slider/index.d.ts",
+      "import": "./dist/slider/index.js"
     }
   },
   "files": [

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -220,3 +220,16 @@ export type {
   RadioRootProps,
   RadioIndicatorProps,
 } from './radio';
+
+export { Slider } from './slider';
+export type {
+  SliderSize,
+  SliderColor,
+  SliderRootProps,
+  SliderLabelProps,
+  SliderValueProps,
+  SliderControlProps,
+  SliderTrackProps,
+  SliderIndicatorProps,
+  SliderThumbProps,
+} from './slider';

--- a/packages/components/src/slider/index.ts
+++ b/packages/components/src/slider/index.ts
@@ -1,0 +1,12 @@
+export { Slider } from './slider';
+export type {
+  SliderSize,
+  SliderColor,
+  SliderRootProps,
+  SliderLabelProps,
+  SliderValueProps,
+  SliderControlProps,
+  SliderTrackProps,
+  SliderIndicatorProps,
+  SliderThumbProps,
+} from './slider';

--- a/packages/components/src/slider/manifest.json
+++ b/packages/components/src/slider/manifest.json
@@ -1,0 +1,258 @@
+{
+  "name": "Slider",
+  "description": "An accessible range input that lets users pick a single value or a range from a continuous scale. Built on Base UI Slider with StyleX styling.",
+  "category": "input",
+  "baseComponent": "@base-ui/react/slider",
+
+  "anatomy": "<Slider.Root defaultValue={50}>\n  <Slider.Label />\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>",
+
+  "parts": {
+    "Root": {
+      "element": "div",
+      "description": "Container that owns slider state (value, min, max, step, orientation) and provides it to child parts.",
+      "props": {
+        "value": {
+          "type": "number | readonly number[]",
+          "description": "The controlled value. Pass an array for a multi-thumb (range) slider."
+        },
+        "defaultValue": {
+          "type": "number | readonly number[]",
+          "description": "The uncontrolled initial value. Array form yields multiple thumbs."
+        },
+        "onValueChange": {
+          "type": "(value, event, details) => void",
+          "description": "Fires while the user is dragging or pressing keys."
+        },
+        "onValueCommitted": {
+          "type": "(value, event, details) => void",
+          "description": "Fires when the user releases the thumb or commits with the keyboard."
+        },
+        "min": { "type": "number", "default": 0, "description": "Minimum allowed value." },
+        "max": { "type": "number", "default": 100, "description": "Maximum allowed value." },
+        "step": { "type": "number", "default": 1, "description": "Increment between values." },
+        "minStepsBetweenValues": {
+          "type": "number",
+          "default": 0,
+          "description": "Minimum step gap enforced between adjacent thumbs in a range slider."
+        },
+        "orientation": {
+          "type": "'horizontal' | 'vertical'",
+          "default": "horizontal",
+          "description": "Slider axis."
+        },
+        "disabled": { "type": "boolean", "default": false, "description": "Disable interaction." },
+        "name": { "type": "string", "description": "Form name." },
+        "format": {
+          "type": "Intl.NumberFormatOptions",
+          "description": "Formatting applied to displayed values (Slider.Value, aria-valuetext)."
+        },
+        "locale": { "type": "string", "description": "Locale for value formatting." },
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects orientation.",
+        "data-disabled": "Present when disabled.",
+        "data-dragging": "Present while a thumb is being dragged."
+      }
+    },
+    "Label": {
+      "element": "label",
+      "description": "Visible label for the slider.",
+      "props": {
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {}
+    },
+    "Value": {
+      "element": "output",
+      "description": "Displays the current value(s) using the Root's locale + format.",
+      "props": {
+        "children": {
+          "type": "(formattedValues, values) => ReactNode",
+          "description": "Optional render function to fully customise the displayed value."
+        },
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {}
+    },
+    "Control": {
+      "element": "div",
+      "description": "The interactive surface that captures pointer events and hosts the track + thumbs.",
+      "props": {
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects orientation.",
+        "data-disabled": "Present when disabled.",
+        "data-dragging": "Present while a thumb is being dragged."
+      }
+    },
+    "Track": {
+      "element": "div",
+      "description": "The unfilled track behind the indicator.",
+      "props": {
+        "size": {
+          "type": "'sm' | 'md' | 'lg'",
+          "default": "md",
+          "description": "Track thickness (sm=4px, md=8px, lg=12px) — matches Progress and Meter."
+        },
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects orientation.",
+        "data-disabled": "Present when disabled."
+      }
+    },
+    "Indicator": {
+      "element": "div",
+      "description": "The filled portion between min and the current value (or between two thumbs in a range slider).",
+      "props": {
+        "color": {
+          "type": "'default' | 'secondary' | 'destructive'",
+          "default": "default",
+          "description": "Fill color."
+        },
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects orientation.",
+        "data-disabled": "Present when disabled."
+      }
+    },
+    "Thumb": {
+      "element": "div",
+      "description": "The draggable handle. Renders a nested input[type=range] with role=slider and aria-valuemin/max/now. Use multiple Thumbs (with index prop) for range sliders.",
+      "props": {
+        "index": {
+          "type": "number",
+          "description": "Required when rendering multiple thumbs for a range slider — corresponds to the index in the value array."
+        },
+        "color": {
+          "type": "'default' | 'secondary' | 'destructive'",
+          "default": "default",
+          "description": "Border color."
+        },
+        "getAriaLabel": {
+          "type": "(index: number) => string",
+          "description": "Returns aria-label for the underlying input — important for unlabelled thumbs."
+        },
+        "getAriaValueText": {
+          "type": "(formatted, value, index) => string",
+          "description": "Returns aria-valuetext — read aloud by screen readers in place of the raw number."
+        },
+        "disabled": { "type": "boolean", "description": "Disable this thumb." },
+        "sx": { "type": "StyleXStyles", "description": "StyleX styles for consumer overrides." }
+      },
+      "dataAttributes": {
+        "data-orientation": "Reflects orientation.",
+        "data-disabled": "Present when disabled.",
+        "data-dragging": "Present while this thumb is being dragged."
+      }
+    }
+  },
+
+  "cssRequirements": null,
+
+  "tokens": [
+    "colorPrimary",
+    "colorSecondary",
+    "colorDestructive",
+    "colorText",
+    "colorTextMuted",
+    "colorMuted",
+    "colorBackground",
+    "colorBorderMuted",
+    "colorFocusRing",
+    "space1h",
+    "fontFamilySans",
+    "fontSizeSm",
+    "fontWeightMedium",
+    "lineHeightNormal",
+    "radiusFull",
+    "borderWidthThick",
+    "motionDurationFast",
+    "motionEaseOut"
+  ],
+
+  "intents": [
+    {
+      "intent": "select-numeric-value",
+      "signals": [
+        "slider",
+        "range input",
+        "pick a value",
+        "scrub",
+        "scrubber",
+        "volume",
+        "brightness"
+      ],
+      "reasoning": "Slider is the right control whenever the user is choosing a single number from a continuous range and rough position matters more than typing exact digits.",
+      "composition": "<Slider.Root defaultValue={50}>\n  <Slider.Label>Volume</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    },
+    {
+      "intent": "select-range",
+      "signals": [
+        "range slider",
+        "min and max",
+        "price range",
+        "filter range",
+        "between values",
+        "two thumbs"
+      ],
+      "reasoning": "A multi-thumb Slider lets users pick a min/max bracket — the canonical range filter UI.",
+      "composition": "<Slider.Root defaultValue={[20, 80]}>\n  <Slider.Label>Price range</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb index={0} />\n      <Slider.Thumb index={1} />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    },
+    {
+      "intent": "vertical-control",
+      "signals": ["vertical slider", "fader", "mixer", "vertical volume"],
+      "reasoning": "Vertical orientation is appropriate for fader-like controls (audio mixers, lighting).",
+      "composition": "<Slider.Root orientation=\"vertical\" defaultValue={50}>\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    }
+  ],
+
+  "avoidWhen": [
+    {
+      "scenario": "User needs to enter a precise number",
+      "reasoning": "Sliders trade precision for visual position. For exact numeric input use Number Field.",
+      "alternative": "NumberField"
+    },
+    {
+      "scenario": "Showing read-only progress or measurement",
+      "reasoning": "Slider is an input. For non-interactive value display use Progress (task progress) or Meter (scalar measurement).",
+      "alternative": "Progress or Meter"
+    },
+    {
+      "scenario": "Choosing between a small set of discrete options",
+      "reasoning": "Sliders are for continuous ranges. For 2–7 discrete choices a Radio group or Toggle Group is clearer.",
+      "alternative": "Radio or ToggleGroup"
+    },
+    {
+      "scenario": "On/off toggle",
+      "reasoning": "A two-state slider is unfamiliar. Use Switch for boolean toggles.",
+      "alternative": "Switch"
+    }
+  ],
+
+  "examples": [
+    {
+      "name": "basic",
+      "description": "Single-value slider with label",
+      "code": "<Slider.Root defaultValue={40}>\n  <Slider.Label>Volume</Slider.Label>\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    },
+    {
+      "name": "controlled",
+      "description": "Controlled slider with displayed value",
+      "code": "const [value, setValue] = useState(40);\n<Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>\n  <Slider.Label>Brightness</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    },
+    {
+      "name": "range",
+      "description": "Range slider with two thumbs",
+      "code": "<Slider.Root defaultValue={[25, 75]} minStepsBetweenValues={1}>\n  <Slider.Label>Price</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb index={0} />\n      <Slider.Thumb index={1} />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    },
+    {
+      "name": "vertical",
+      "description": "Vertical fader",
+      "code": "<Slider.Root orientation=\"vertical\" defaultValue={60}>\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>"
+    }
+  ]
+}

--- a/packages/components/src/slider/slider.md
+++ b/packages/components/src/slider/slider.md
@@ -1,0 +1,201 @@
+# Slider
+
+An accessible range input that lets users pick a single value or a range from a continuous scale. Built on [Base UI Slider](https://base-ui.com/react/components/slider).
+
+## Anatomy
+
+```tsx
+<Slider.Root defaultValue={50}>
+  <Slider.Label />
+  <Slider.Value />
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+- **Root** -- Owns slider state (value, min, max, step, orientation).
+- **Label** -- Visible label.
+- **Value** -- Displays the current value(s) using `format`/`locale` from Root.
+- **Control** -- Interactive surface; captures pointer drag.
+- **Track** -- The unfilled background.
+- **Indicator** -- Filled portion between min and value (or between two thumbs).
+- **Thumb** -- The draggable handle. Render multiple `Thumb`s with `index` for a range slider.
+
+## Examples
+
+### Basic
+
+```tsx
+<Slider.Root defaultValue={40}>
+  <Slider.Label>Volume</Slider.Label>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+### Controlled with value display
+
+```tsx
+const [value, setValue] = useState(40);
+
+<Slider.Root value={value} onValueChange={(v) => setValue(v as number)}>
+  <Slider.Label>Brightness</Slider.Label>
+  <Slider.Value />
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>;
+```
+
+### Range (multi-value)
+
+```tsx
+<Slider.Root defaultValue={[25, 75]} minStepsBetweenValues={1}>
+  <Slider.Label>Price</Slider.Label>
+  <Slider.Value />
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb index={0} />
+      <Slider.Thumb index={1} />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+### Vertical
+
+```tsx
+<Slider.Root orientation="vertical" defaultValue={60}>
+  <Slider.Control>
+    <Slider.Track>
+      <Slider.Indicator />
+      <Slider.Thumb />
+    </Slider.Track>
+  </Slider.Control>
+</Slider.Root>
+```
+
+### Inside a Field
+
+```tsx
+<Field.Root>
+  <Field.Label>Quality</Field.Label>
+  <Slider.Root defaultValue={50}>
+    <Slider.Control>
+      <Slider.Track>
+        <Slider.Indicator />
+        <Slider.Thumb />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+  <Field.Description>Lower values save bandwidth.</Field.Description>
+</Field.Root>
+```
+
+## Keyboard
+
+| Key                 | Action                                      |
+| ------------------- | ------------------------------------------- |
+| `Arrow Left/Down`   | Decrement by `step` (RTL: increments)       |
+| `Arrow Right/Up`    | Increment by `step` (RTL: decrements)       |
+| `Page Down`         | Decrement by a larger step (10 \* step)     |
+| `Page Up`           | Increment by a larger step (10 \* step)     |
+| `Home`              | Jump to `min`                               |
+| `End`               | Jump to `max`                               |
+| `Tab` / `Shift+Tab` | Move focus between thumbs in a range slider |
+
+## API Reference
+
+### Slider.Root
+
+| Prop                    | Type                              | Default        | Description                                                  |
+| ----------------------- | --------------------------------- | -------------- | ------------------------------------------------------------ |
+| `value`                 | `number \| readonly number[]`     | --             | Controlled value. Pass an array for a range slider.          |
+| `defaultValue`          | `number \| readonly number[]`     | --             | Uncontrolled initial value.                                  |
+| `onValueChange`         | `(value, event, details) => void` | --             | Fires while dragging or pressing keys.                       |
+| `onValueCommitted`      | `(value, event, details) => void` | --             | Fires on release / keyboard commit.                          |
+| `min`                   | `number`                          | `0`            | Minimum allowed value.                                       |
+| `max`                   | `number`                          | `100`          | Maximum allowed value.                                       |
+| `step`                  | `number`                          | `1`            | Increment between values.                                    |
+| `minStepsBetweenValues` | `number`                          | `0`            | Minimum step gap between adjacent thumbs.                    |
+| `orientation`           | `'horizontal' \| 'vertical'`      | `'horizontal'` | Slider axis.                                                 |
+| `disabled`              | `boolean`                         | `false`        | Disable interaction.                                         |
+| `name`                  | `string`                          | --             | Form name.                                                   |
+| `format`                | `Intl.NumberFormatOptions`        | --             | Formatting applied to displayed values and `aria-valuetext`. |
+| `locale`                | `string`                          | --             | Locale for formatting.                                       |
+| `sx`                    | `StyleXStyles`                    | --             | StyleX overrides.                                            |
+
+### Slider.Label
+
+| Prop | Type           | Default | Description       |
+| ---- | -------------- | ------- | ----------------- |
+| `sx` | `StyleXStyles` | --      | StyleX overrides. |
+
+### Slider.Value
+
+| Prop       | Type                               | Default | Description                                          |
+| ---------- | ---------------------------------- | ------- | ---------------------------------------------------- |
+| `children` | `(formatted, values) => ReactNode` | --      | Optional render fn to customise the displayed value. |
+| `sx`       | `StyleXStyles`                     | --      | StyleX overrides.                                    |
+
+### Slider.Control
+
+| Prop | Type           | Default | Description       |
+| ---- | -------------- | ------- | ----------------- |
+| `sx` | `StyleXStyles` | --      | StyleX overrides. |
+
+Data attributes: `data-orientation`, `data-disabled`, `data-dragging`.
+
+### Slider.Track
+
+| Prop   | Type                   | Default | Description                                                           |
+| ------ | ---------------------- | ------- | --------------------------------------------------------------------- |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'`  | Track thickness — sm=4px, md=8px, lg=12px (matches Progress / Meter). |
+| `sx`   | `StyleXStyles`         | --      | StyleX overrides.                                                     |
+
+### Slider.Indicator
+
+| Prop    | Type                                        | Default     | Description       |
+| ------- | ------------------------------------------- | ----------- | ----------------- |
+| `color` | `'default' \| 'secondary' \| 'destructive'` | `'default'` | Fill color.       |
+| `sx`    | `StyleXStyles`                              | --          | StyleX overrides. |
+
+### Slider.Thumb
+
+| Prop               | Type                                        | Default     | Description                                                                      |
+| ------------------ | ------------------------------------------- | ----------- | -------------------------------------------------------------------------------- |
+| `index`            | `number`                                    | --          | Required for range sliders — corresponds to the index in the value array.        |
+| `color`            | `'default' \| 'secondary' \| 'destructive'` | `'default'` | Border color.                                                                    |
+| `getAriaLabel`     | `(index: number) => string`                 | --          | Returns `aria-label` for the underlying input — important for unlabelled thumbs. |
+| `getAriaValueText` | `(formatted, value, index) => string`       | --          | Returns `aria-valuetext`.                                                        |
+| `disabled`         | `boolean`                                   | `false`     | Disable this thumb.                                                              |
+| `sx`               | `StyleXStyles`                              | --          | StyleX overrides.                                                                |
+
+## When to Use
+
+- Choosing a single number from a continuous range when rough position matters more than precision (volume, brightness).
+- Picking a min/max bracket (price range, date range filter).
+- Vertical "fader" controls (mixers, lighting).
+
+## When NOT to Use
+
+- **Precise numeric input** -- use `NumberField`.
+- **Read-only value display** -- use `Progress` (task progress) or `Meter` (scalar measurement).
+- **2–7 discrete choices** -- use `Radio` or `ToggleGroup`.
+- **On/off toggle** -- use `Switch`.
+
+## RTL
+
+Slider mirrors automatically when wrapped in `dir="rtl"`. The visual fill anchors to the trailing edge and `Arrow Left/Right` swap their increment direction to match the visual axis. No code changes are required.

--- a/packages/components/src/slider/slider.test.ts
+++ b/packages/components/src/slider/slider.test.ts
@@ -1,0 +1,48 @@
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@stylexjs/stylex', () => {
+  const m = {
+    create: (s: Record<string, unknown>) => s,
+    props: () => ({ className: '' }),
+    defineVars: (v: Record<string, unknown>) => v,
+    createTheme: () => ({}),
+  };
+  return { default: m, ...m };
+});
+vi.mock('@basex-ui/tokens', () => ({
+  tokens: new Proxy({}, { get: (_, p) => `var(--${String(p)})` }),
+}));
+vi.mock('@basex-ui/styles', () => ({
+  focusRing: {},
+  capitalize: (s: string) => s,
+}));
+
+import { Slider } from './index';
+
+describe('Slider', () => {
+  it('exports all compound parts', () => {
+    expect(Slider.Root).toBeDefined();
+    expect(Slider.Label).toBeDefined();
+    expect(Slider.Value).toBeDefined();
+    expect(Slider.Control).toBeDefined();
+    expect(Slider.Track).toBeDefined();
+    expect(Slider.Indicator).toBeDefined();
+    expect(Slider.Thumb).toBeDefined();
+  });
+
+  it('sets displayName on all parts', () => {
+    expect(Slider.Root.displayName).toBe('Slider.Root');
+    expect(Slider.Label.displayName).toBe('Slider.Label');
+    expect(Slider.Value.displayName).toBe('Slider.Value');
+    expect(Slider.Control.displayName).toBe('Slider.Control');
+    expect(Slider.Track.displayName).toBe('Slider.Track');
+    expect(Slider.Indicator.displayName).toBe('Slider.Indicator');
+    expect(Slider.Thumb.displayName).toBe('Slider.Thumb');
+  });
+
+  it('does not expose unexpected parts', () => {
+    const expectedParts = ['Root', 'Label', 'Value', 'Control', 'Track', 'Indicator', 'Thumb'];
+    const actualParts = Object.keys(Slider);
+    expect(actualParts.sort()).toEqual(expectedParts.sort());
+  });
+});

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -1,0 +1,296 @@
+import { Slider as BaseSlider } from '@base-ui/react/slider';
+import * as stylex from '@stylexjs/stylex';
+import { tokens } from '@basex-ui/tokens';
+import { focusRing } from '@basex-ui/styles';
+import { forwardRef } from 'react';
+import type { StyleXStyles } from '@stylexjs/stylex';
+
+// --- Styles ---
+// Track height (8px) and indicator color come from Progress/Meter conventions
+// so the visual language stays unified across feedback + input range components.
+// Thumb size (16px) matches Number Field button width minimums and the focus
+// ring utility from @basex-ui/styles is reused for keyboard focus parity.
+const styles = stylex.create({
+  root: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.space1h,
+    width: '100%',
+    touchAction: 'none',
+    // Vertical orientation
+    ':is([data-orientation="vertical"])': {
+      height: '160px',
+      width: 'auto',
+    },
+  },
+
+  rootDisabled: {
+    cursor: 'not-allowed',
+  },
+
+  label: {
+    fontSize: tokens.fontSizeSm,
+    fontWeight: tokens.fontWeightMedium,
+    fontFamily: tokens.fontFamilySans,
+    color: tokens.colorText,
+    lineHeight: tokens.lineHeightNormal,
+  },
+
+  value: {
+    fontSize: tokens.fontSizeSm,
+    fontFamily: tokens.fontFamilySans,
+    color: tokens.colorTextMuted,
+    lineHeight: tokens.lineHeightNormal,
+  },
+
+  control: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    height: '20px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    touchAction: 'none',
+    // Vertical orientation
+    ':is([data-orientation="vertical"])': {
+      height: '100%',
+      width: '20px',
+      flexDirection: 'column',
+    },
+  },
+
+  controlDisabled: {
+    cursor: 'not-allowed',
+  },
+
+  track: {
+    position: 'relative',
+    width: '100%',
+    height: '8px',
+    backgroundColor: tokens.colorMuted,
+    borderRadius: tokens.radiusFull,
+    overflow: 'hidden',
+    ':is([data-orientation="vertical"])': {
+      width: '8px',
+      height: '100%',
+    },
+  },
+
+  trackSizeSm: {
+    height: '4px',
+    ':is([data-orientation="vertical"])': {
+      width: '4px',
+      height: '100%',
+    },
+  },
+  trackSizeMd: {
+    height: '8px',
+    ':is([data-orientation="vertical"])': {
+      width: '8px',
+      height: '100%',
+    },
+  },
+  trackSizeLg: {
+    height: '12px',
+    ':is([data-orientation="vertical"])': {
+      width: '12px',
+      height: '100%',
+    },
+  },
+
+  indicator: {
+    position: 'absolute',
+    backgroundColor: tokens.colorPrimary,
+    borderRadius: tokens.radiusFull,
+    transitionProperty: 'background-color',
+    transitionDuration: tokens.motionDurationFast,
+    transitionTimingFunction: tokens.motionEaseOut,
+  },
+
+  indicatorSecondary: {
+    backgroundColor: tokens.colorSecondary,
+  },
+
+  indicatorDestructive: {
+    backgroundColor: tokens.colorDestructive,
+  },
+
+  indicatorDisabled: {
+    backgroundColor: tokens.colorBorderMuted,
+  },
+
+  thumb: {
+    display: 'block',
+    width: '16px',
+    height: '16px',
+    backgroundColor: tokens.colorBackground,
+    borderWidth: tokens.borderWidthThick,
+    borderStyle: 'solid',
+    borderColor: tokens.colorPrimary,
+    borderRadius: tokens.radiusFull,
+    cursor: 'grab',
+    transitionProperty: 'border-color, background-color, transform',
+    transitionDuration: tokens.motionDurationFast,
+    transitionTimingFunction: tokens.motionEaseOut,
+    ':active': {
+      cursor: 'grabbing',
+    },
+  },
+
+  thumbSecondary: {
+    borderColor: tokens.colorSecondary,
+  },
+
+  thumbDestructive: {
+    borderColor: tokens.colorDestructive,
+  },
+
+  thumbDisabled: {
+    borderColor: tokens.colorBorderMuted,
+    cursor: 'not-allowed',
+  },
+});
+
+// --- Types ---
+export type SliderSize = 'sm' | 'md' | 'lg';
+export type SliderColor = 'default' | 'secondary' | 'destructive';
+
+export interface SliderRootProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Root>,
+  'className'
+> {
+  sx?: StyleXStyles;
+}
+
+export interface SliderValueProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Value>,
+  'className'
+> {
+  sx?: StyleXStyles;
+}
+
+export interface SliderControlProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Control>,
+  'className'
+> {
+  sx?: StyleXStyles;
+}
+
+export interface SliderTrackProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Track>,
+  'className'
+> {
+  size?: SliderSize;
+  sx?: StyleXStyles;
+}
+
+export interface SliderIndicatorProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Indicator>,
+  'className'
+> {
+  color?: SliderColor;
+  sx?: StyleXStyles;
+}
+
+export interface SliderThumbProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof BaseSlider.Thumb>,
+  'className'
+> {
+  color?: SliderColor;
+  sx?: StyleXStyles;
+}
+
+export interface SliderLabelProps extends React.HTMLAttributes<HTMLLabelElement> {
+  sx?: StyleXStyles;
+}
+
+// --- Components ---
+
+const Root = forwardRef<HTMLDivElement, SliderRootProps>(({ sx, ...props }, ref) => (
+  <BaseSlider.Root
+    ref={ref}
+    {...props}
+    className={`basex-slider-root ${
+      stylex.props(styles.root, props.disabled && styles.rootDisabled, sx).className ?? ''
+    }`}
+  />
+));
+Root.displayName = 'Slider.Root';
+
+const Label = forwardRef<HTMLLabelElement, SliderLabelProps>(({ sx, ...props }, ref) => (
+  <label ref={ref} {...props} className={stylex.props(styles.label, sx).className ?? ''} />
+));
+Label.displayName = 'Slider.Label';
+
+const Value = forwardRef<HTMLOutputElement, SliderValueProps>(({ sx, ...props }, ref) => (
+  <BaseSlider.Value
+    ref={ref}
+    {...props}
+    className={stylex.props(styles.value, sx).className ?? ''}
+  />
+));
+Value.displayName = 'Slider.Value';
+
+const Control = forwardRef<HTMLDivElement, SliderControlProps>(({ sx, ...props }, ref) => (
+  <BaseSlider.Control
+    ref={ref}
+    {...props}
+    className={`basex-slider-control ${stylex.props(styles.control, sx).className ?? ''}`}
+  />
+));
+Control.displayName = 'Slider.Control';
+
+const Track = forwardRef<HTMLDivElement, SliderTrackProps>(({ size = 'md', sx, ...props }, ref) => {
+  const sizeStyle =
+    size === 'sm' ? styles.trackSizeSm : size === 'lg' ? styles.trackSizeLg : styles.trackSizeMd;
+  return (
+    <BaseSlider.Track
+      ref={ref}
+      {...props}
+      className={`basex-slider-track ${stylex.props(styles.track, sizeStyle, sx).className ?? ''}`}
+    />
+  );
+});
+Track.displayName = 'Slider.Track';
+
+const Indicator = forwardRef<HTMLDivElement, SliderIndicatorProps>(
+  ({ color = 'default', sx, ...props }, ref) => (
+    <BaseSlider.Indicator
+      ref={ref}
+      {...props}
+      className={`basex-slider-indicator ${
+        stylex.props(
+          styles.indicator,
+          color === 'secondary' && styles.indicatorSecondary,
+          color === 'destructive' && styles.indicatorDestructive,
+          sx,
+        ).className ?? ''
+      }`}
+    />
+  ),
+);
+Indicator.displayName = 'Slider.Indicator';
+
+const Thumb = forwardRef<HTMLDivElement, SliderThumbProps>(
+  ({ color = 'default', sx, ...props }, ref) => (
+    <BaseSlider.Thumb
+      ref={ref}
+      {...props}
+      className={`basex-slider-thumb ${
+        stylex.props(
+          styles.thumb,
+          color === 'secondary' && styles.thumbSecondary,
+          color === 'destructive' && styles.thumbDestructive,
+          focusRing,
+          sx,
+        ).className ?? ''
+      }`}
+    />
+  ),
+);
+Thumb.displayName = 'Slider.Thumb';
+
+// --- Public API ---
+export const Slider = { Root, Label, Value, Control, Track, Indicator, Thumb };

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -8,8 +8,10 @@ import type { StyleXStyles } from '@stylexjs/stylex';
 // --- Styles ---
 // Track height (8px) and indicator color come from Progress/Meter conventions
 // so the visual language stays unified across feedback + input range components.
-// Thumb size (16px) matches Number Field button width minimums and the focus
-// ring utility from @basex-ui/styles is reused for keyboard focus parity.
+// Thumb size (20px) overhangs the 8px track on each side so the handle reads
+// as a clearly grabbable button. Filled with colorPrimary + shadowSm to lift
+// it off the track; the focus ring utility from @basex-ui/styles is reused
+// for keyboard focus parity.
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -124,16 +126,19 @@ const styles = stylex.create({
   thumb: {
     display: 'block',
     boxSizing: 'border-box',
-    width: '16px',
-    height: '16px',
-    backgroundColor: tokens.colorText,
+    width: '20px',
+    height: '20px',
+    backgroundColor: tokens.colorPrimary,
     borderRadius: tokens.radiusSm,
+    boxShadow: tokens.shadowSm,
     cursor: 'grab',
     transitionProperty: 'box-shadow, transform',
     transitionDuration: tokens.motionDurationFast,
     transitionTimingFunction: tokens.motionEaseOut,
     ':hover': {
-      boxShadow: `0 0 0 4px ${tokens.colorMuted}`,
+      '@media (hover: hover) and (pointer: fine)': {
+        boxShadow: `${tokens.shadowSm}, 0 0 0 4px ${tokens.colorMuted}`,
+      },
     },
     ':active': {
       cursor: 'grabbing',

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -73,7 +73,7 @@ const styles = stylex.create({
     height: '8px',
     backgroundColor: tokens.colorMuted,
     borderRadius: tokens.radiusFull,
-    overflow: 'hidden',
+    overflow: 'visible',
     ':is([data-orientation="vertical"])': {
       width: '8px',
       height: '100%',
@@ -128,7 +128,7 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     width: '20px',
     height: '20px',
-    backgroundColor: tokens.colorPrimary,
+    backgroundColor: tokens.colorText,
     borderRadius: tokens.radiusSm,
     boxShadow: tokens.shadowSm,
     cursor: 'grab',

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -9,9 +9,11 @@ import type { StyleXStyles } from '@stylexjs/stylex';
 // Track height (8px) and indicator color come from Progress/Meter conventions
 // so the visual language stays unified across feedback + input range components.
 // Thumb size (20px) overhangs the 8px track on each side so the handle reads
-// as a clearly grabbable button. Filled with colorPrimary + shadowMd to lift
-// it off the track (shadowSm was too subtle when foreground = orange indicator
-// background); the focus ring utility from @basex-ui/styles is reused for
+// as a clearly grabbable button. Filled with colorPrimary and defined by a
+// 1px inset edge in colorBorder (neutral grey) — this gives the thumb a crisp
+// outline against both the orange indicator AND the white page surface, where
+// shadowMd alone was too faint to register. shadowMd is layered underneath for
+// subtle elevation; the focus ring utility from @basex-ui/styles is reused for
 // keyboard focus parity.
 const styles = stylex.create({
   root: {
@@ -131,14 +133,14 @@ const styles = stylex.create({
     height: '20px',
     backgroundColor: tokens.colorPrimary,
     borderRadius: tokens.radiusSm,
-    boxShadow: tokens.shadowMd,
+    boxShadow: `inset 0 0 0 1px ${tokens.colorBorder}, ${tokens.shadowMd}`,
     cursor: 'grab',
     transitionProperty: 'box-shadow, transform',
     transitionDuration: tokens.motionDurationFast,
     transitionTimingFunction: tokens.motionEaseOut,
     ':hover': {
       '@media (hover: hover) and (pointer: fine)': {
-        boxShadow: `${tokens.shadowMd}, 0 0 0 4px ${tokens.colorMuted}`,
+        boxShadow: `inset 0 0 0 1px ${tokens.colorBorder}, ${tokens.shadowMd}, 0 0 0 4px ${tokens.colorMuted}`,
       },
     },
     ':active': {

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -9,9 +9,10 @@ import type { StyleXStyles } from '@stylexjs/stylex';
 // Track height (8px) and indicator color come from Progress/Meter conventions
 // so the visual language stays unified across feedback + input range components.
 // Thumb size (20px) overhangs the 8px track on each side so the handle reads
-// as a clearly grabbable button. Filled with colorPrimary + shadowSm to lift
-// it off the track; the focus ring utility from @basex-ui/styles is reused
-// for keyboard focus parity.
+// as a clearly grabbable button. Filled with colorPrimary + shadowMd to lift
+// it off the track (shadowSm was too subtle when foreground = orange indicator
+// background); the focus ring utility from @basex-ui/styles is reused for
+// keyboard focus parity.
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -128,16 +129,16 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     width: '20px',
     height: '20px',
-    backgroundColor: tokens.colorText,
+    backgroundColor: tokens.colorPrimary,
     borderRadius: tokens.radiusSm,
-    boxShadow: tokens.shadowSm,
+    boxShadow: tokens.shadowMd,
     cursor: 'grab',
     transitionProperty: 'box-shadow, transform',
     transitionDuration: tokens.motionDurationFast,
     transitionTimingFunction: tokens.motionEaseOut,
     ':hover': {
       '@media (hover: hover) and (pointer: fine)': {
-        boxShadow: `${tokens.shadowSm}, 0 0 0 4px ${tokens.colorMuted}`,
+        boxShadow: `${tokens.shadowMd}, 0 0 0 4px ${tokens.colorMuted}`,
       },
     },
     ':active': {

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -126,37 +126,26 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     width: '16px',
     height: '16px',
-    backgroundColor: tokens.colorBackground,
-    borderWidth: tokens.borderWidthDefault,
-    borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    backgroundColor: tokens.colorText,
     borderRadius: tokens.radiusSm,
-    boxShadow: tokens.shadowSm,
     cursor: 'grab',
-    transitionProperty: 'border-color, background-color, box-shadow, transform',
+    transitionProperty: 'box-shadow, transform',
     transitionDuration: tokens.motionDurationFast,
     transitionTimingFunction: tokens.motionEaseOut,
     ':hover': {
-      backgroundColor: tokens.colorMuted,
-      borderColor: tokens.colorText,
+      boxShadow: `0 0 0 4px ${tokens.colorMuted}`,
     },
     ':active': {
       cursor: 'grabbing',
-      backgroundColor: tokens.colorMuted,
-      borderColor: tokens.colorText,
     },
   },
 
-  thumbSecondary: {
-    borderColor: tokens.colorBorder,
-  },
+  thumbSecondary: {},
 
-  thumbDestructive: {
-    borderColor: tokens.colorBorder,
-  },
+  thumbDestructive: {},
 
   thumbDisabled: {
-    borderColor: tokens.colorBorderMuted,
+    opacity: 0.5,
     cursor: 'not-allowed',
   },
 });

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     'src/preview-card/index.ts',
     'src/progress/index.ts',
     'src/radio/index.ts',
+    'src/slider/index.ts',
   ],
   format: ['esm'],
   dts: true,

--- a/packages/intelligence/intents.json
+++ b/packages/intelligence/intents.json
@@ -49,14 +49,14 @@
       "intent": "show-hide-content",
       "component": "Accordion",
       "signals": ["show more", "reveal", "toggle content", "expandable", "progressive disclosure"],
-      "reasoning": "Accordion provides progressive disclosure — content is hidden by default and revealed on demand, reducing cognitive load.",
+      "reasoning": "Accordion provides progressive disclosure \u2014 content is hidden by default and revealed on demand, reducing cognitive load.",
       "composition": "<Accordion.Root>\n  <Accordion.Item value=\"details\">\n    <Accordion.Header>\n      <Accordion.Trigger>Show details</Accordion.Trigger>\n    </Accordion.Header>\n    <Accordion.Panel>Hidden content revealed on click</Accordion.Panel>\n  </Accordion.Item>\n</Accordion.Root>"
     },
     {
       "intent": "faq-list",
       "component": "Accordion",
       "signals": ["FAQ", "questions", "answers", "help", "Q&A", "knowledge base"],
-      "reasoning": "FAQ lists are a classic accordion pattern — each question is a trigger, each answer is a panel. Use single-open mode to keep focus.",
+      "reasoning": "FAQ lists are a classic accordion pattern \u2014 each question is a trigger, each answer is a panel. Use single-open mode to keep focus.",
       "composition": "<Accordion.Root>\n  <Accordion.Item value=\"q1\">\n    <Accordion.Header>\n      <Accordion.Trigger>How do I reset my password?</Accordion.Trigger>\n    </Accordion.Header>\n    <Accordion.Panel>Visit the settings page and click \"Reset Password\".</Accordion.Panel>\n  </Accordion.Item>\n</Accordion.Root>"
     },
     {
@@ -186,7 +186,7 @@
       "intent": "single-disclosure",
       "component": "Collapsible",
       "signals": ["show more", "reveal", "toggle content", "expandable", "disclosure"],
-      "reasoning": "Collapsible provides simple progressive disclosure — content is hidden by default and revealed on demand with an animated panel.",
+      "reasoning": "Collapsible provides simple progressive disclosure \u2014 content is hidden by default and revealed on demand with an animated panel.",
       "composition": "<Collapsible.Root>\n  <Collapsible.Trigger>Show details</Collapsible.Trigger>\n  <Collapsible.Panel>Hidden content revealed on click</Collapsible.Panel>\n</Collapsible.Root>"
     },
     {
@@ -534,6 +534,42 @@
       "signals": ["preference", "settings choice", "plan selection", "tier", "mode selector"],
       "reasoning": "Radio groups work well for preference or settings where users pick exactly one option from a small set.",
       "composition": "<Radio.Group defaultValue=\"standard\">\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"standard\"><Radio.Indicator /></Radio.Root>\n    Standard\n  </label>\n  <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>\n    <Radio.Root value=\"express\"><Radio.Indicator /></Radio.Root>\n    Express\n  </label>\n</Radio.Group>"
+    },
+    {
+      "intent": "select-numeric-value",
+      "signals": [
+        "slider",
+        "range input",
+        "pick a value",
+        "scrub",
+        "scrubber",
+        "volume",
+        "brightness"
+      ],
+      "reasoning": "Slider is the right control whenever the user is choosing a single number from a continuous range and rough position matters more than typing exact digits.",
+      "composition": "<Slider.Root defaultValue={50}>\n  <Slider.Label>Volume</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>",
+      "component": "Slider"
+    },
+    {
+      "intent": "select-range",
+      "signals": [
+        "range slider",
+        "min and max",
+        "price range",
+        "filter range",
+        "between values",
+        "two thumbs"
+      ],
+      "reasoning": "A multi-thumb Slider lets users pick a min/max bracket \u2014 the canonical range filter UI.",
+      "composition": "<Slider.Root defaultValue={[20, 80]}>\n  <Slider.Label>Price range</Slider.Label>\n  <Slider.Value />\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb index={0} />\n      <Slider.Thumb index={1} />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>",
+      "component": "Slider"
+    },
+    {
+      "intent": "vertical-control",
+      "signals": ["vertical slider", "fader", "mixer", "vertical volume"],
+      "reasoning": "Vertical orientation is appropriate for fader-like controls (audio mixers, lighting).",
+      "composition": "<Slider.Root orientation=\"vertical\" defaultValue={50}>\n  <Slider.Control>\n    <Slider.Track>\n      <Slider.Indicator />\n      <Slider.Thumb />\n    </Slider.Track>\n  </Slider.Control>\n</Slider.Root>",
+      "component": "Slider"
     }
   ],
   "antiPatterns": [
@@ -600,7 +636,7 @@
     {
       "component": "AlertDialog",
       "scenario": "A dismissible overlay that can be closed by clicking outside",
-      "reasoning": "AlertDialog cannot be dismissed by clicking outside — that's by design. Use Dialog if you want backdrop dismissal.",
+      "reasoning": "AlertDialog cannot be dismissed by clicking outside \u2014 that's by design. Use Dialog if you want backdrop dismissal.",
       "alternative": "Use Dialog from @base-ui/react/dialog."
     },
     {
@@ -690,7 +726,7 @@
     {
       "component": "Combobox",
       "scenario": "Free-form text input with suggestions",
-      "reasoning": "Use Autocomplete instead. Combobox requires selection from a predefined list — the value is a selection, not free text.",
+      "reasoning": "Use Autocomplete instead. Combobox requires selection from a predefined list \u2014 the value is a selection, not free text.",
       "alternative": "Autocomplete"
     },
     {
@@ -708,7 +744,7 @@
     {
       "component": "Autocomplete",
       "scenario": "User must select from a fixed set of options (no free text)",
-      "reasoning": "Use Select or Combobox instead. Autocomplete allows free-form text input — the value is the text itself, not a selection.",
+      "reasoning": "Use Select or Combobox instead. Autocomplete allows free-form text input \u2014 the value is the text itself, not a selection.",
       "alternative": "Use Select or Combobox."
     },
     {
@@ -744,7 +780,7 @@
     {
       "component": "Field",
       "scenario": "A standalone label without an input control",
-      "reasoning": "Use a plain <label> element. Field's value is in connecting label, control, and error — without a control it adds no benefit.",
+      "reasoning": "Use a plain <label> element. Field's value is in connecting label, control, and error \u2014 without a control it adds no benefit.",
       "alternative": "Plain <label> element"
     },
     {
@@ -956,6 +992,30 @@
       "scenario": "Binary on/off toggle",
       "reasoning": "Use Switch for a single boolean toggle. Radio is for choosing between labeled options.",
       "alternative": "Switch"
+    },
+    {
+      "scenario": "User needs to enter a precise number",
+      "reasoning": "Sliders trade precision for visual position. For exact numeric input use Number Field.",
+      "alternative": "NumberField",
+      "component": "Slider"
+    },
+    {
+      "scenario": "Showing read-only progress or measurement",
+      "reasoning": "Slider is an input. For non-interactive value display use Progress (task progress) or Meter (scalar measurement).",
+      "alternative": "Progress or Meter",
+      "component": "Slider"
+    },
+    {
+      "scenario": "Choosing between a small set of discrete options",
+      "reasoning": "Sliders are for continuous ranges. For 2\u20137 discrete choices a Radio group or Toggle Group is clearer.",
+      "alternative": "Radio or ToggleGroup",
+      "component": "Slider"
+    },
+    {
+      "scenario": "On/off toggle",
+      "reasoning": "A two-state slider is unfamiliar. Use Switch for boolean toggles.",
+      "alternative": "Switch",
+      "component": "Slider"
     }
   ]
 }

--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -13,7 +13,7 @@ describe('listComponents', () => {
     const names = list.map((c) => c.name);
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
-    expect(list).toHaveLength(24);
+    expect(list).toHaveLength(25);
   });
 });
 

--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -14,7 +14,7 @@ describe('listComponents', () => {
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
     expect(names).toContain('Tabs');
-    expect(list).toHaveLength(30);
+    expect(list).toHaveLength(31);
   });
 });
 

--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -14,7 +14,7 @@ describe('listComponents', () => {
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
     expect(names).toContain('Tabs');
-    expect(list).toHaveLength(29);
+    expect(list).toHaveLength(30);
   });
 });
 

--- a/packages/mcp-server/src/data.ts
+++ b/packages/mcp-server/src/data.ts
@@ -38,6 +38,7 @@ import popoverManifest from '../../components/src/popover/manifest.json';
 import previewCardManifest from '../../components/src/preview-card/manifest.json';
 import progressManifest from '../../components/src/progress/manifest.json';
 import radioManifest from '../../components/src/radio/manifest.json';
+import sliderManifest from '../../components/src/slider/manifest.json';
 
 export type ComponentManifest =
   | typeof buttonManifest
@@ -63,7 +64,8 @@ export type ComponentManifest =
   | typeof popoverManifest
   | typeof previewCardManifest
   | typeof progressManifest
-  | typeof radioManifest;
+  | typeof radioManifest
+  | typeof sliderManifest;
 
 const components = new Map<string, ComponentManifest>([
   ['button', buttonManifest],
@@ -90,6 +92,7 @@ const components = new Map<string, ComponentManifest>([
   ['preview-card', previewCardManifest],
   ['progress', progressManifest],
   ['radio', radioManifest],
+  ['slider', sliderManifest],
 ] as [string, ComponentManifest][]);
 
 // ---------------------------------------------------------------------------
@@ -262,6 +265,11 @@ export function getComponentSetup(name: string): ComponentSetup | null {
       { interaction: 'indeterminate animation', preset: 'Move' },
     ],
     radio: [{ interaction: 'indicator appear/disappear', preset: 'State' }],
+    slider: [
+      { interaction: 'thumb hover/focus ring', preset: 'State' },
+      { interaction: 'thumb drag (transform)', preset: 'Move' },
+      { interaction: 'indicator color transition', preset: 'State' },
+    ],
   };
 
   return {


### PR DESCRIPTION
## Anatomy

```tsx
<Slider.Root defaultValue={50}>
  <Slider.Label />
  <Slider.Value />
  <Slider.Control>
    <Slider.Track>
      <Slider.Indicator />
      <Slider.Thumb />
    </Slider.Track>
  </Slider.Control>
</Slider.Root>
```

`Slider.Root` owns state. `Control` is the pointer surface. `Track` holds `Indicator` (fill) and one or many `Thumb`s. Range slider = render multiple `Thumb`s with `index={n}`.

## Tokens used (with source component)

| Token              | Source           | Usage                              |
| ------------------ | ---------------- | ---------------------------------- |
| `colorMuted`       | Progress / Meter | Track background                   |
| `colorPrimary`     | Progress / Meter | Indicator fill, Thumb border       |
| `colorSecondary`   | Progress / Meter | Indicator/Thumb `color="secondary"`|
| `colorDestructive` | Progress / Meter | Indicator/Thumb `color="destructive"`|
| `colorBackground`  | Number Field     | Thumb fill                         |
| `colorBorderMuted` | Number Field     | Disabled border + fill             |
| `colorFocusRing`   | (focusRing util) | Thumb focus-visible ring           |
| `radiusFull`       | Progress / Meter | Track + indicator + thumb          |
| `borderWidthThick` | Tokens           | 2px thumb border                   |
| `space1h`          | Progress / Meter | Root gap                           |
| `fontFamilySans`, `fontSizeSm`, `fontWeightMedium`, `lineHeightNormal` | Progress / Meter | Label + Value typography |
| `motionDurationFast`, `motionEaseOut` | Number Field | Color/transform transitions |

Track heights match Progress / Meter: `sm=4px`, `md=8px`, `lg=12px`. No new tokens introduced.

## Keyboard map

| Key                 | Action                                       |
| ------------------- | -------------------------------------------- |
| Arrow Left / Down   | Decrement by `step` (RTL: increments)        |
| Arrow Right / Up    | Increment by `step` (RTL: decrements)        |
| Page Down           | Decrement by 10 × step                       |
| Page Up             | Increment by 10 × step                       |
| Home / End          | Jump to `min` / `max`                        |
| Tab / Shift+Tab     | Move focus between thumbs in a range slider  |

Provided by Base UI; we layer the shared `focusRing` utility (matches Input, NumberField, Combobox, etc.) on Thumb so the focus-visible ring is consistent system-wide.

## RTL decisions

- Slider mirrors automatically inside `dir="rtl"` (Base UI flips axis + key direction).
- `Indicator` uses `position: absolute` + `top/inset` driven by Base UI data attributes; no manual `left/right` overrides that would break under RTL.
- Vertical orientation toggles via `:is([data-orientation="vertical"])` selectors so no JS branching is needed.
- `touch-action: none` on Root + Control to give clean drag on touch devices.

## What needs review

1. **Vertical layout sizing.** Vertical Root collapses to `height: 160px` by default. Open question: should the docs/page own that, or is a sensible default on Root the right call?
2. **`SliderColor` on Thumb vs Indicator.** Currently both accept it independently — easy for them to drift. Consider hoisting to Root if a unified color is preferable.
3. **Disabled state on Indicator.** `indicatorDisabled` style is defined but not wired (Base UI sets `data-disabled`; we could attach via attr selector). Pattern across Progress/Meter doesn't gate disabled either, so it was left consistent.
4. **Value composition.** Demo wraps Label + Value in a flex row inside Root; we could add a `Slider.Header` component but I held the line on minimal anatomy.
5. **Roadmap order.** Roadmap had Scroll Area as **Next**; this PR ships Slider out-of-order (per direct ask). Roadmap updated to mark Slider Done while keeping Scroll Area as Next.

## Verify

- `pnpm -w build` passes (all packages + docs)
- `pnpm -w test` passes (53/53; updated `listComponents` count to 25)
- `pnpm -w lint` clean (1 preexisting unrelated warning)