### PR TITLE
fix(mcp-server): bump component count assertion to 26

### DIFF
--- a/packages/mcp-server/src/data.test.ts
+++ b/packages/mcp-server/src/data.test.ts
@@ -13,7 +13,7 @@ describe('listComponents', () => {
     const names = list.map((c) => c.name);
     expect(names).toContain('Button');
     expect(names).toContain('Accordion');
-    expect(list).toHaveLength(25);
+    expect(list).toHaveLength(26);
   });
 });
 


### PR DESCRIPTION
Switch merge missed updating `data.test.ts` from 25 to 26. All 59 tests pass locally with the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)