### PR TITLE
chore(components): add @types/react-dom + react-dom devDeps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -151,7 +151,9 @@
     "@stylexjs/babel-plugin": "^0.17.5",
     "@stylexjs/stylex": "^0.17.5",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,6 @@ importers:
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.4)
-      react-dom:
-        specifier: '>=18.0.0'
-        version: 19.2.4(react@19.2.4)
     devDependencies:
       '@stylexjs/babel-plugin':
         specifier: ^0.17.5
@@ -149,9 +146,15 @@ importers:
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
       react:
         specifier: ^19.0.0
         version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)


### PR DESCRIPTION
Restores typecheck on main. `separator.test.ts` (merged in PR #29) imports `react-dom/server` but the types weren't declared.

`pnpm typecheck` and `pnpm test:ci` (59/59) clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)