### PR TITLE
chore(docs): remove Controlled demo blocks across all components

### DIFF
--- a/apps/docs/src/pages/SwitchPage.tsx
+++ b/apps/docs/src/pages/SwitchPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { Switch, Field, Form } from '@basex-ui/components';
 import { tokens } from '@basex-ui/tokens';
@@ -27,18 +26,6 @@ const pageStyles = stylex.create({
   },
 });
 
-function ControlledExample() {
-  const [checked, setChecked] = useState(false);
-  return (
-    <label {...stylex.props(pageStyles.label)}>
-      <Switch.Root checked={checked} onCheckedChange={setChecked}>
-        <Switch.Thumb />
-      </Switch.Root>
-      Dark mode {checked ? '(on)' : '(off)'}
-    </label>
-  );
-}
-
 export function SwitchPage() {
   return (
     <>
@@ -58,18 +45,6 @@ export function SwitchPage() {
           </Switch.Root>
           Enable notifications
         </label>
-      </Preview>
-
-      <Preview
-        title="Controlled"
-        description="Use checked + onCheckedChange to drive the switch from React state."
-        code={`const [checked, setChecked] = useState(false);
-
-<Switch.Root checked={checked} onCheckedChange={setChecked}>
-  <Switch.Thumb />
-</Switch.Root>`}
-      >
-        <ControlledExample />
       </Preview>
 
       <Preview

--- a/docs/new-component-checklist.md
+++ b/docs/new-component-checklist.md
@@ -106,6 +106,7 @@ Copy from `_template/component.md` and fill in:
 - [ ] Use the `Preview` component from `../components/Preview` for every demo section
   - Each `Preview` gets a `title`, `description`, and the demo as children
   - Use `constrained` prop for full-width components (e.g. Accordion) to cap inner width
+  - Do not include a Controlled-state demo card. Controlled mode is documented in the component's markdown API doc.
 - [ ] Register in `apps/docs/src/App.tsx`: import, add to `pages` array with `id`, `label`, `description`, `component`
 - [ ] Add any required global CSS to `apps/docs/src/index.css`
 


### PR DESCRIPTION
## Summary

Removes the "Controlled" demo Preview card from component docs pages. The rendered output is visually identical to the basic uncontrolled demo, so the card is docs noise rather than pedagogy. Controlled-vs-uncontrolled belongs in the markdown API doc, not in a live demo.

## What changed

- `apps/docs/src/pages/SwitchPage.tsx` — drop `Controlled` Preview, drop `ControlledExample` helper, drop unused `useState` import.
- `docs/new-component-checklist.md` — add a one-liner forbidding Controlled demo cards in future component pages.

## What needs review

- Confirm Switch was the only page on main with a Controlled demo card (audit covered all 28 `*Page.tsx` files; only SwitchPage matched).
- Open feat PRs for tabs/slider/toggle/select/tooltip/toolbar/toggle-group/toast will be cleaned up separately on their own branches.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing unrelated warning in App.tsx)
- [x] `pnpm test:ci` 62 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)