### PR TITLE
chore: guard hover styles behind hover-capable media query

### DIFF
--- a/packages/components/src/autocomplete/autocomplete.tsx
+++ b/packages/components/src/autocomplete/autocomplete.tsx
@@ -77,7 +77,10 @@ const styles = stylex.create({
     color: tokens.colorIcon,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderWidth: 0,
     borderRadius: tokens.radiusSm,

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -39,7 +39,10 @@ const styles = stylex.create({
   variantSolid: {
     backgroundColor: {
       default: tokens.colorPrimary,
-      ':hover': tokens.colorPrimaryHover,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorPrimaryHover,
+      },
       ':active': tokens.colorPrimaryActive,
     },
     color: tokens.colorPrimaryContrast,
@@ -48,7 +51,10 @@ const styles = stylex.create({
   variantOutline: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     color: tokens.colorText,
     borderColor: tokens.colorBorder,
@@ -56,7 +62,10 @@ const styles = stylex.create({
   variantGhost: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     color: tokens.colorText,
     borderColor: 'transparent',
@@ -66,7 +75,10 @@ const styles = stylex.create({
   solidSecondary: {
     backgroundColor: {
       default: tokens.colorSecondary,
-      ':hover': tokens.colorSecondaryHover,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorSecondaryHover,
+      },
       ':active': tokens.colorSecondaryActive,
     },
     color: tokens.colorSecondaryContrast,
@@ -74,7 +86,10 @@ const styles = stylex.create({
   solidDestructive: {
     backgroundColor: {
       default: tokens.colorDestructive,
-      ':hover': tokens.colorDestructiveHover,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveHover,
+      },
       ':active': tokens.colorDestructiveActive,
     },
     color: tokens.colorDestructiveContrast,
@@ -82,18 +97,27 @@ const styles = stylex.create({
   outlineDestructive: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorDestructiveMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveMuted,
+      },
     },
     color: tokens.colorDestructive,
     borderColor: {
       default: tokens.colorBorder,
-      ':hover': tokens.colorDestructive,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorDestructive,
+      },
     },
   },
   ghostDestructive: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorDestructiveMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveMuted,
+      },
     },
     color: tokens.colorDestructive,
   },

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -101,7 +101,10 @@ const styles = stylex.create({
     color: tokens.colorIcon,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderWidth: 0,
     borderRadius: tokens.radiusSm,
@@ -246,7 +249,10 @@ const styles = stylex.create({
     padding: 0,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorBorderMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorBorderMuted,
+      },
     },
     transitionProperty: 'color, background-color',
     transitionDuration: tokens.motionDurationFast,

--- a/packages/components/src/dialog/dialog.tsx
+++ b/packages/components/src/dialog/dialog.tsx
@@ -50,7 +50,10 @@ const styles = stylex.create({
     cursor: 'pointer',
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     transitionProperty: 'background-color, color',
     transitionDuration: tokens.motionDurationFast,

--- a/packages/components/src/drawer/drawer.tsx
+++ b/packages/components/src/drawer/drawer.tsx
@@ -107,7 +107,10 @@ const styles = stylex.create({
     cursor: 'pointer',
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     transitionProperty: 'background-color, color',
     transitionDuration: tokens.motionDurationFast,

--- a/packages/components/src/menu/menu.tsx
+++ b/packages/components/src/menu/menu.tsx
@@ -19,7 +19,10 @@ const styles = stylex.create({
     color: tokens.colorText,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
@@ -71,7 +74,10 @@ const styles = stylex.create({
     color: tokens.colorText,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     cursor: 'pointer',
     userSelect: 'none',
@@ -86,7 +92,10 @@ const styles = stylex.create({
     color: tokens.colorDestructive,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorDestructiveMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveMuted,
+      },
     },
   },
 
@@ -110,7 +119,10 @@ const styles = stylex.create({
     textDecoration: 'none',
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     cursor: 'pointer',
     transitionProperty: 'background-color, color',
@@ -194,7 +206,10 @@ const styles = stylex.create({
     color: tokens.colorText,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     cursor: 'pointer',
     userSelect: 'none',

--- a/packages/components/src/navigation-menu/navigation-menu.tsx
+++ b/packages/components/src/navigation-menu/navigation-menu.tsx
@@ -39,7 +39,10 @@ const styles = stylex.create({
     color: tokens.colorTextMuted,
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderWidth: 0,
     borderRadius: tokens.radiusMd,
@@ -67,7 +70,10 @@ const styles = stylex.create({
     textDecoration: 'none',
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderRadius: tokens.radiusMd,
     cursor: 'pointer',

--- a/packages/components/src/number-field/number-field.tsx
+++ b/packages/components/src/number-field/number-field.tsx
@@ -70,7 +70,10 @@ const styles = stylex.create({
     border: 'none',
     backgroundColor: {
       default: tokens.colorMuted,
-      ':hover': tokens.colorBorderMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorBorderMuted,
+      },
       ':active': tokens.colorBorder,
     },
     color: tokens.colorIcon,
@@ -94,7 +97,10 @@ const styles = stylex.create({
     cursor: 'not-allowed',
     backgroundColor: {
       default: 'transparent',
-      ':hover': 'transparent',
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': 'transparent',
+      },
     },
   },
 

--- a/packages/components/src/popover/popover.tsx
+++ b/packages/components/src/popover/popover.tsx
@@ -69,7 +69,10 @@ const styles = stylex.create({
     border: 'none',
     backgroundColor: {
       default: 'transparent',
-      ':hover': tokens.colorMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
+      },
     },
     borderRadius: tokens.radiusSm,
     color: tokens.colorIcon,

--- a/packages/components/src/preview-card/preview-card.tsx
+++ b/packages/components/src/preview-card/preview-card.tsx
@@ -10,7 +10,10 @@ const styles = stylex.create({
     color: tokens.colorPrimary,
     textDecoration: {
       default: 'none',
-      ':hover': 'underline',
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': 'underline',
+      },
     },
     cursor: 'pointer',
     fontFamily: tokens.fontFamilySans,

--- a/packages/components/src/tabs/tabs.tsx
+++ b/packages/components/src/tabs/tabs.tsx
@@ -54,13 +54,19 @@ const styles = stylex.create({
     lineHeight: tokens.lineHeightTight,
     color: {
       default: tokens.colorTextMuted,
-      ':hover': tokens.colorText,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorText,
+      },
     },
     // Inactive tabs carry a faint fill so each trigger reads as a
     // clickable chip (Spotify-style nav). Hover bumps one notch.
     backgroundColor: {
       default: tokens.colorMuted,
-      ':hover': tokens.colorBorderMuted,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorBorderMuted,
+      },
     },
     borderWidth: 0,
     borderRadius: tokens.radiusSm,
@@ -77,11 +83,17 @@ const styles = stylex.create({
   tabActive: {
     color: {
       default: tokens.colorTextInverse,
-      ':hover': tokens.colorTextInverse,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorTextInverse,
+      },
     },
     backgroundColor: {
       default: tokens.colorText,
-      ':hover': tokens.colorText,
+      ':hover': {
+        default: null,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorText,
+      },
     },
   },
 


### PR DESCRIPTION
## Summary
- Wrap every `:hover` rule across merged components in `@media (hover: hover) and (pointer: fine)` so hover styles only apply to mouse/trackpad users.
- Fixes the classic sticky-hover-on-tap bug: touch devices fire `:hover` on tap and don't clear it until the next tap elsewhere, leaving toggles/items/buttons visually stuck in a hovered state after the user moves on.
- Pure mobile-hover safety pass, no behavioral changes for pointer users.

## Decisions
- StyleX idiom (no prior precedent in the repo): nested condition on the property value, e.g.
  ```ts
  backgroundColor: {
    default: 'transparent',
    ':hover': {
      default: null,
      '@media (hover: hover) and (pointer: fine)': tokens.colorMuted,
    },
  }
  ```
- `default: null` inside `:hover` falls through to the outer `default`, so on touch the hover branch is a no-op.
- Skipped `scroll-area/thumb` (uses a different StyleX shape and is a scrollbar, not a tap target).

## Files
`autocomplete`, `button`, `combobox`, `dialog`, `drawer`, `menu`, `navigation-menu`, `number-field`, `popover`, `preview-card`, `tabs` — 28 hover rules total.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing warning only)
- [x] `pnpm test:ci` — 65/65 passing
- [ ] Manual: tap a Tabs trigger / Menu item / Button on mobile and confirm it returns to default state after release (no sticky hover background)
- [ ] Manual: hover the same components on desktop with a mouse and confirm hover styles still apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)