### PR TITLE
fix(radio): invert checked dot color per theme

### DIFF
--- a/packages/components/src/radio/radio.tsx
+++ b/packages/components/src/radio/radio.tsx
@@ -52,7 +52,7 @@ const styles = stylex.create({
     width: '6px',
     height: '6px',
     borderRadius: tokens.radiusFull,
-    backgroundColor: tokens.colorPrimaryContrast,
+    backgroundColor: tokens.colorTextInverse,
   },
 });
 


### PR DESCRIPTION
## What changed
- `packages/components/src/radio/radio.tsx` — Indicator `backgroundColor` swapped from `tokens.colorPrimaryContrast` to `tokens.colorTextInverse`.

## Why
The radio's checked indicator dot was pinned white in both themes via `colorPrimaryContrast` (which industry-standard correctly stays white as text-on-orange). The dot is a decorative shape, not on-primary text — it should invert with the theme like Switch and active Tabs already do.

`colorTextInverse` resolves to `oklch(0.98 0 0)` (near-white) in light mode and `oklch(0.15 0.02 260)` (near-black) in dark mode. Both maintain strong contrast against the checked fill (`colorPrimary` orange).

## Scope
Single-token swap on Radio Indicator only. `colorPrimaryContrast` semantics untouched everywhere else.

## Verification
- `pnpm typecheck` clean
- `pnpm lint` clean (one pre-existing unrelated warning in `App.tsx`)
- `pnpm test:ci` 70/70 passing

## Needs review
- Visual confirmation on Vercel preview that the dot reads correctly against orange in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)