### PR TITLE
chore(components): wire switch into tsup + package exports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -133,6 +133,10 @@
       "types": "./dist/slider/index.d.ts",
       "import": "./dist/slider/index.js"
     },
+    "./switch": {
+      "types": "./dist/switch/index.d.ts",
+      "import": "./dist/switch/index.js"
+    },
     "./tabs": {
       "types": "./dist/tabs/index.d.ts",
       "import": "./dist/tabs/index.js"

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     'src/scroll-area/index.ts',
     'src/separator/index.ts',
     'src/slider/index.ts',
+    'src/switch/index.ts',
     'src/tabs/index.ts',
     'src/toggle/index.ts',
     'src/tooltip/index.ts',


### PR DESCRIPTION
Switch source files were merged in PR #19 but never wired into the build entry list or package.json exports map, so importing from `@basex-ui/components/switch` would not resolve.

`pnpm typecheck`, `pnpm test:ci` (73/73), and `pnpm --filter @basex-ui/components build` all clean locally. Build now emits `dist/switch/index.{js,d.ts}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)