### PR TITLE
fix(toggle): align pressed state with Toolbar.ToggleItem

### DIFF
--- a/packages/components/src/toggle/toggle.tsx
+++ b/packages/components/src/toggle/toggle.tsx
@@ -67,17 +67,24 @@ const styles = stylex.create({
   },
 
   // --- Pressed (on) state ---
-  // Filled primary, identical tokens to Button variant="solid".
+  // Mirrors Toolbar.ToggleItem: theme-inverting `colorText` fill +
+  // `colorTextInverse` foreground. Hover overrides hold the pressed state
+  // stable so the on-state never weakens on hover.
   pressed: {
     backgroundColor: {
-      default: tokens.colorPrimary,
+      default: tokens.colorText,
       ':hover': {
-        default: tokens.colorPrimary,
-        '@media (hover: hover) and (pointer: fine)': tokens.colorPrimaryHover,
+        default: tokens.colorText,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorText,
       },
-      ':active': tokens.colorPrimaryActive,
     },
-    color: tokens.colorPrimaryContrast,
+    color: {
+      default: tokens.colorTextInverse,
+      ':hover': {
+        default: tokens.colorTextInverse,
+        '@media (hover: hover) and (pointer: fine)': tokens.colorTextInverse,
+      },
+    },
     borderColor: 'transparent',
   },
 


### PR DESCRIPTION
## Summary
- Replaces Toggle's pressed state primary-color chain (`colorPrimary`/`colorPrimaryHover`/`colorPrimaryActive` + `colorPrimaryContrast`) with the Toolbar.ToggleItem contract: `colorText` background + `colorTextInverse` foreground.
- Mirrors Toolbar's hover-locked overrides so the on-state never weakens on hover.
- Drops the pressed border (set to transparent).

## What changed
- `packages/components/src/toggle/toggle.tsx` — only the `pressed` style block. No API change. No variant/size/disabled changes.

## Why
Standalone Toggle and Toolbar.ToggleItem now share the same theme-inverting filled-block pressed treatment. Removes the visual divergence between primitives that should read as the same control.

## Test plan
- [x] `pnpm lint` passes (1 pre-existing warning, unrelated)
- [x] `pnpm format` clean
- [x] `pnpm test:ci` — 80/80 passing
- [ ] Note: `pnpm typecheck` fails on `packages/styles/src/themes.stylex.ts` with a pre-existing `colorSuccess` token error — reproducible on clean `main`, unrelated to this change.
- [ ] Visual check: Toggle pressed state now matches Toolbar.ToggleItem in light + dark.