### PR TITLE
fix: pnpm typecheck self-bootstraps by building first

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "pnpm -r run build",
     "dev": "pnpm -r --parallel run dev",
     "clean": "pnpm -r run clean",
-    "typecheck": "pnpm -r run typecheck",
+    "typecheck": "pnpm build && pnpm -r run typecheck",
     "test": "vitest",
     "test:ci": "vitest run",
     "lint": "eslint packages/ apps/",


### PR DESCRIPTION
Root `pnpm typecheck` now runs `pnpm build` before per-package tsc. Fresh checkouts of the monorepo (including PR branches) used to fail typecheck because downstream packages resolve `@basex-ui/tokens` types from `./dist/index.d.ts`, which is gitignored. Adding `colorSuccess` to the tokens source then surfaced as a typecheck error in `packages/styles` until the tokens package was rebuilt locally.

Did NOT modify `.github/workflows/ci.yml` (PAT lacks `workflow` scope) — would be a worthy follow-up to add `pnpm -r run typecheck` to CI between build and test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)