### PR TITLE
Token-level contrast pass: dark + light AA fixes

### DIFF
--- a/packages/components/src/autocomplete/autocomplete.tsx
+++ b/packages/components/src/autocomplete/autocomplete.tsx
@@ -24,7 +24,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     '::placeholder': {
       color: tokens.colorTextPlaceholder,
     },
@@ -138,7 +138,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurface,
     borderWidth: '1px',
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusMd,
     boxShadow: tokens.shadowMd,
     overflow: 'hidden',

--- a/packages/components/src/avatar/avatar.tsx
+++ b/packages/components/src/avatar/avatar.tsx
@@ -30,7 +30,7 @@ const styles = stylex.create({
     width: '100%',
     height: '100%',
     backgroundColor: tokens.colorMuted,
-    color: tokens.colorMutedForeground,
+    color: tokens.colorText,
     fontFamily: tokens.fontFamilySans,
     fontSize: tokens.fontSizeSm,
     fontWeight: tokens.fontWeightMedium,

--- a/packages/components/src/button/button.tsx
+++ b/packages/components/src/button/button.tsx
@@ -102,7 +102,7 @@ const styles = stylex.create({
         '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveMuted,
       },
     },
-    color: tokens.colorDestructive,
+    color: tokens.colorDestructiveText,
     borderColor: {
       default: tokens.colorBorder,
       ':hover': {
@@ -119,7 +119,7 @@ const styles = stylex.create({
         '@media (hover: hover) and (pointer: fine)': tokens.colorDestructiveMuted,
       },
     },
-    color: tokens.colorDestructive,
+    color: tokens.colorDestructiveText,
   },
 
   // --- Size axis ---

--- a/packages/components/src/checkbox/checkbox.tsx
+++ b/packages/components/src/checkbox/checkbox.tsx
@@ -17,7 +17,7 @@ const styles = stylex.create({
     borderRadius: tokens.radiusSm,
     borderWidth: tokens.borderWidthThick,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     backgroundColor: 'transparent',
     cursor: 'pointer',
     flexShrink: 0,

--- a/packages/components/src/combobox/combobox.tsx
+++ b/packages/components/src/combobox/combobox.tsx
@@ -46,7 +46,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     '::placeholder': {
       color: tokens.colorTextPlaceholder,
     },
@@ -129,7 +129,7 @@ const styles = stylex.create({
     maxWidth: '18rem',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     outlineWidth: {
       default: 0,
       ':focus-within': '2px',
@@ -274,7 +274,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurface,
     borderWidth: '1px',
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusMd,
     boxShadow: tokens.shadowMd,
     overflow: 'hidden',

--- a/packages/components/src/field/field.tsx
+++ b/packages/components/src/field/field.tsx
@@ -33,7 +33,7 @@ const styles = stylex.create({
   error: {
     fontSize: tokens.fontSizeSm,
     fontFamily: tokens.fontFamilySans,
-    color: tokens.colorDestructive,
+    color: tokens.colorDestructiveText,
     lineHeight: tokens.lineHeightNormal,
   },
 
@@ -44,7 +44,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     borderRadius: tokens.radiusMd,
     lineHeight: tokens.lineHeightNormal,
     '::placeholder': {

--- a/packages/components/src/input/input.tsx
+++ b/packages/components/src/input/input.tsx
@@ -14,7 +14,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     borderRadius: tokens.radiusMd,
     lineHeight: tokens.lineHeightNormal,
     '::placeholder': {

--- a/packages/components/src/menu/menu.tsx
+++ b/packages/components/src/menu/menu.tsx
@@ -54,7 +54,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurface,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusLg,
     paddingBlock: tokens.space1,
     boxShadow: tokens.shadowLg,
@@ -89,7 +89,7 @@ const styles = stylex.create({
   },
 
   itemDestructive: {
-    color: tokens.colorDestructive,
+    color: tokens.colorDestructiveText,
     backgroundColor: {
       default: 'transparent',
       ':hover': {
@@ -133,7 +133,7 @@ const styles = stylex.create({
 
   separator: {
     height: '1px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorBorder,
     marginBlock: tokens.space1,
   },
 

--- a/packages/components/src/menubar/menubar.tsx
+++ b/packages/components/src/menubar/menubar.tsx
@@ -13,7 +13,7 @@ const styles = stylex.create({
     fontFamily: tokens.fontFamilySans,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorBorder,
     borderRadius: tokens.radiusLg,
     paddingBlock: tokens.space1,
     paddingInline: tokens.space1,

--- a/packages/components/src/meter/meter.tsx
+++ b/packages/components/src/meter/meter.tsx
@@ -25,7 +25,7 @@ const styles = stylex.create({
     position: 'relative',
     width: '100%',
     height: '8px',
-    backgroundColor: tokens.colorMuted,
+    backgroundColor: tokens.colorTrack,
     borderRadius: tokens.radiusFull,
     overflow: 'hidden',
   },

--- a/packages/components/src/navigation-menu/navigation-menu.tsx
+++ b/packages/components/src/navigation-menu/navigation-menu.tsx
@@ -106,7 +106,7 @@ const styles = stylex.create({
   arrow: {
     width: '12px',
     height: '8px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorPopoverBorder,
     clipPath: 'polygon(50% 0%, 100% 100%, 0% 100%)',
     position: 'relative',
     '::after': {
@@ -129,7 +129,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurface,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusLg,
     boxShadow: tokens.shadowLg,
     // visible (not hidden) so nested Positioner popups can render outside parent popup bounds

--- a/packages/components/src/number-field/number-field.tsx
+++ b/packages/components/src/number-field/number-field.tsx
@@ -18,7 +18,7 @@ const styles = stylex.create({
     alignItems: 'stretch',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     borderRadius: tokens.radiusMd,
     overflow: 'hidden',
     backgroundColor: tokens.colorBackground,

--- a/packages/components/src/popover/popover.tsx
+++ b/packages/components/src/popover/popover.tsx
@@ -11,7 +11,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurfaceRaised,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusLg,
     padding: tokens.space3,
     boxShadow: tokens.shadowLg,
@@ -26,7 +26,7 @@ const styles = stylex.create({
   arrow: {
     width: '12px',
     height: '8px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorPopoverBorder,
     clipPath: 'polygon(50% 0%, 100% 100%, 0% 100%)',
     position: 'relative',
     '::after': {

--- a/packages/components/src/preview-card/preview-card.tsx
+++ b/packages/components/src/preview-card/preview-card.tsx
@@ -23,7 +23,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurfaceRaised,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusLg,
     padding: tokens.space3,
     boxShadow: tokens.shadowLg,
@@ -38,7 +38,7 @@ const styles = stylex.create({
   arrow: {
     width: '12px',
     height: '8px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorPopoverBorder,
     clipPath: 'polygon(50% 0%, 100% 100%, 0% 100%)',
     position: 'relative',
     '::after': {

--- a/packages/components/src/progress/progress.tsx
+++ b/packages/components/src/progress/progress.tsx
@@ -25,7 +25,7 @@ const styles = stylex.create({
     position: 'relative',
     width: '100%',
     height: '8px',
-    backgroundColor: tokens.colorMuted,
+    backgroundColor: tokens.colorTrack,
     borderRadius: tokens.radiusFull,
     overflow: 'hidden',
   },

--- a/packages/components/src/radio/radio.tsx
+++ b/packages/components/src/radio/radio.tsx
@@ -28,7 +28,7 @@ const styles = stylex.create({
     borderRadius: tokens.radiusFull,
     borderWidth: tokens.borderWidthThick,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     backgroundColor: tokens.colorBackground,
     cursor: 'pointer',
     flexShrink: 0,

--- a/packages/components/src/select/select.tsx
+++ b/packages/components/src/select/select.tsx
@@ -22,7 +22,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
     cursor: 'pointer',
     userSelect: 'none',
     textAlign: 'start',
@@ -92,7 +92,7 @@ const styles = stylex.create({
     backgroundColor: tokens.colorSurface,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     borderRadius: tokens.radiusMd,
     boxShadow: tokens.shadowMd,
     overflow: 'hidden',
@@ -227,7 +227,7 @@ const styles = stylex.create({
 
   separator: {
     height: '1px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorBorder,
     marginBlock: tokens.space1,
     marginInline: tokens.space1,
   },

--- a/packages/components/src/separator/separator.tsx
+++ b/packages/components/src/separator/separator.tsx
@@ -9,7 +9,7 @@ const styles = stylex.create({
   horizontal: {
     width: '100%',
     height: '1px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorBorder,
     flexShrink: 0,
     border: 0,
   },
@@ -17,7 +17,7 @@ const styles = stylex.create({
     width: '1px',
     height: '100%',
     alignSelf: 'stretch',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorBorder,
     flexShrink: 0,
     border: 0,
   },

--- a/packages/components/src/slider/slider.tsx
+++ b/packages/components/src/slider/slider.tsx
@@ -74,7 +74,7 @@ const styles = stylex.create({
     position: 'relative',
     width: '100%',
     height: '8px',
-    backgroundColor: tokens.colorMuted,
+    backgroundColor: tokens.colorTrack,
     borderRadius: tokens.radiusFull,
     overflow: 'visible',
     ':is([data-orientation="vertical"])': {

--- a/packages/components/src/switch/switch.tsx
+++ b/packages/components/src/switch/switch.tsx
@@ -17,8 +17,8 @@ const styles = stylex.create({
     borderRadius: tokens.radiusFull,
     borderWidth: tokens.borderWidthThick,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorder,
-    backgroundColor: tokens.colorBorder,
+    borderColor: tokens.colorBorderStrong,
+    backgroundColor: tokens.colorBorderStrong,
     cursor: 'pointer',
     flexShrink: 0,
     transitionProperty: 'background-color, border-color',
@@ -42,15 +42,19 @@ const styles = stylex.create({
     width: '10px',
     height: '10px',
     borderRadius: tokens.radiusFull,
-    backgroundColor: tokens.colorTextInverse,
+    // Unchecked thumb sits on the colorBorderStrong track — using colorText
+    // gives a strong dark-on-mid (light) and light-on-mid (dark) contrast.
+    backgroundColor: tokens.colorText,
     transform: 'translateX(0)',
-    transitionProperty: 'transform',
+    transitionProperty: 'transform, background-color',
     transitionDuration: tokens.motionDurationFast,
     transitionTimingFunction: tokens.motionEaseOut,
   },
 
   thumbChecked: {
     transform: 'translateX(14px)',
+    // Checked thumb sits on the colorText track — invert to stay readable.
+    backgroundColor: tokens.colorTextInverse,
   },
 });
 

--- a/packages/components/src/toast/toast.tsx
+++ b/packages/components/src/toast/toast.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     boxShadow: tokens.shadowLg,
     borderWidth: '1px',
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorPopoverBorder,
     pointerEvents: 'auto',
     fontFamily: tokens.fontFamilySans,
     touchAction: 'none',

--- a/packages/components/src/toolbar/toolbar.tsx
+++ b/packages/components/src/toolbar/toolbar.tsx
@@ -20,7 +20,7 @@ const styles = stylex.create({
     fontFamily: tokens.fontFamilySans,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: tokens.colorBorder,
     borderRadius: tokens.radiusLg,
     paddingBlock: tokens.space1,
     paddingInline: tokens.space1,
@@ -130,7 +130,7 @@ const styles = stylex.create({
   },
 
   separator: {
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorBorder,
     flexShrink: 0,
   },
 

--- a/packages/components/src/tooltip/tooltip.tsx
+++ b/packages/components/src/tooltip/tooltip.tsx
@@ -5,22 +5,24 @@ import { forwardRef } from 'react';
 import type { StyleXStyles } from '@stylexjs/stylex';
 
 // --- Styles ---
-// Matches Popover content treatment so they read as a family. Same surface,
-// border, radius, shadow, and motion tokens — only padding and maxWidth are
-// tighter because tooltips host short, non-interactive text.
+// Linear-style invert: tooltip surface flips per theme via the colorText /
+// colorTextInverse pair. In light mode, colorText is dark → dark tooltip on
+// white page. In dark mode, colorText is light → light tooltip on dark page.
+// This makes tooltips visually distinct from popovers (which stay surface-tinted)
+// in both themes without needing CSS conditionals.
 const styles = stylex.create({
   popup: {
-    backgroundColor: tokens.colorSurfaceRaised,
+    backgroundColor: tokens.colorText,
     borderWidth: tokens.borderWidthDefault,
     borderStyle: 'solid',
-    borderColor: tokens.colorBorderMuted,
+    borderColor: 'transparent',
     borderRadius: tokens.radiusLg,
     paddingBlock: tokens.space1,
     paddingInline: tokens.space2,
     boxShadow: tokens.shadowLg,
     fontFamily: tokens.fontFamilySans,
     fontSize: tokens.fontSizeSm,
-    color: tokens.colorText,
+    color: tokens.colorTextInverse,
     lineHeight: tokens.lineHeightNormal,
     maxWidth: '240px',
     outline: 'none',
@@ -29,7 +31,7 @@ const styles = stylex.create({
   arrow: {
     width: '12px',
     height: '8px',
-    backgroundColor: tokens.colorBorderMuted,
+    backgroundColor: tokens.colorText,
     clipPath: 'polygon(50% 0%, 100% 100%, 0% 100%)',
     position: 'relative',
     '::after': {
@@ -39,7 +41,7 @@ const styles = stylex.create({
       left: '1px',
       right: '1px',
       bottom: 0,
-      backgroundColor: tokens.colorSurfaceRaised,
+      backgroundColor: tokens.colorText,
       clipPath: 'polygon(50% 0%, 100% 100%, 0% 100%)',
     },
   },

--- a/packages/styles/src/themes.stylex.ts
+++ b/packages/styles/src/themes.stylex.ts
@@ -23,9 +23,11 @@ export const lightTheme = stylex.createTheme(tokens, {
   colorDestructiveActive: 'oklch(0.45 0.26 25)',
   colorDestructiveContrast: 'oklch(0.98 0 0)',
   colorDestructiveMuted: 'oklch(0.55 0.22 25 / 0.1)',
+  colorDestructiveText: 'oklch(0.45 0.22 25)',
 
   colorSuccess: 'oklch(0.65 0.17 145)',
   colorSuccessContrast: 'oklch(0.98 0 0)',
+  colorSuccessText: 'oklch(0.45 0.17 145)',
 
   colorMuted: 'oklch(0.93 0.005 260)',
   colorMutedForeground: 'oklch(0.45 0.02 260)',
@@ -36,15 +38,19 @@ export const lightTheme = stylex.createTheme(tokens, {
 
   colorOverlay: 'oklch(0.15 0 0 / 0.6)',
 
-  colorBorder: 'oklch(0.85 0.01 260)',
-  colorBorderMuted: 'oklch(0.91 0.005 260)',
+  colorBorder: 'oklch(0.75 0.01 260)',
+  colorBorderMuted: 'oklch(0.85 0.01 260)',
+  colorBorderStrong: 'oklch(0.7 0.01 260)',
+  colorPopoverBorder: 'oklch(0.78 0.01 260)',
+  colorTrack: 'oklch(0.88 0.005 260)',
 
   colorText: 'oklch(0.15 0.02 260)',
   colorTextMuted: 'oklch(0.45 0.02 260)',
+  colorIcon: 'oklch(0.6 0.01 260)',
   colorTextPlaceholder: 'oklch(0.62 0.01 260)',
   colorTextInverse: 'oklch(0.98 0 0)',
 
-  colorFocusRing: 'oklch(0.7 0 0)',
+  colorFocusRing: 'oklch(0.55 0 0)',
   colorBackground: '#ffffff',
 
   space1: '4px',
@@ -133,10 +139,13 @@ export const darkTheme = stylex.createTheme(tokens, {
   colorDestructiveActive: 'oklch(0.60 0.18 25)',
   colorDestructiveContrast: 'oklch(0.15 0 0)',
   colorDestructiveMuted: 'oklch(0.65 0.20 25 / 0.15)',
+  // Lifted destructive text for AA (4.5:1) on dark surfaces.
+  colorDestructiveText: 'oklch(0.78 0.18 25)',
 
   // Success — slightly brighter on dark backgrounds
   colorSuccess: 'oklch(0.72 0.18 145)',
   colorSuccessContrast: 'oklch(0.15 0 0)',
+  colorSuccessText: 'oklch(0.78 0.15 145)',
 
   // Muted
   colorMuted: 'oklch(0.25 0.01 260)',
@@ -150,18 +159,23 @@ export const darkTheme = stylex.createTheme(tokens, {
   // Overlay — darker backdrop
   colorOverlay: 'oklch(0.05 0 0 / 0.8)',
 
-  // Borders — subtle on dark
-  colorBorder: 'oklch(0.35 0.01 260)',
-  colorBorderMuted: 'oklch(0.28 0.005 260)',
+  // Borders — bumped for AA non-text contrast (1.4.11)
+  colorBorder: 'oklch(0.42 0.01 260)',
+  colorBorderMuted: 'oklch(0.36 0.01 260)',
+  colorBorderStrong: 'oklch(0.5 0.01 260)',
+  colorPopoverBorder: 'oklch(0.40 0.01 260)',
+  colorTrack: 'oklch(0.30 0.01 260)',
 
   // Text — light on dark
   colorText: 'oklch(0.93 0.005 260)',
   colorTextMuted: 'oklch(0.65 0.02 260)',
+  // Formalize the L=0.6 coincidence — explicit per-theme override.
+  colorIcon: 'oklch(0.65 0.01 260)',
   colorTextPlaceholder: 'oklch(0.48 0.01 260)',
   colorTextInverse: 'oklch(0.15 0.02 260)',
 
   // Focus — lighter neutral for dark backgrounds
-  colorFocusRing: 'oklch(0.55 0 0)',
+  colorFocusRing: 'oklch(0.65 0 0)',
 
   // Background
   colorBackground: 'oklch(0.16 0.01 260)',

--- a/packages/tokens/src/tokens.stylex.ts
+++ b/packages/tokens/src/tokens.stylex.ts
@@ -27,10 +27,15 @@ export const tokens = stylex.defineVars({
   colorDestructiveActive: 'oklch(0.45 0.26 25)',
   colorDestructiveContrast: 'oklch(0.98 0 0)',
   colorDestructiveMuted: 'oklch(0.55 0.22 25 / 0.1)',
+  // Foreground variant for destructive text on neutral surfaces (menus, fields,
+  // ghost/outline buttons). Distinct from `colorDestructive` (used as bg fill).
+  colorDestructiveText: 'oklch(0.45 0.22 25)',
 
   // Success palette
   colorSuccess: 'oklch(0.65 0.17 145)',
   colorSuccessContrast: 'oklch(0.98 0 0)',
+  // Foreground variant for success text on neutral surfaces.
+  colorSuccessText: 'oklch(0.45 0.17 145)',
 
   // Muted
   colorMuted: 'oklch(0.93 0.005 260)',
@@ -45,8 +50,16 @@ export const tokens = stylex.defineVars({
   colorOverlay: 'oklch(0.15 0 0 / 0.6)',
 
   // Borders
-  colorBorder: 'oklch(0.85 0.01 260)',
-  colorBorderMuted: 'oklch(0.91 0.005 260)',
+  colorBorder: 'oklch(0.75 0.01 260)',
+  colorBorderMuted: 'oklch(0.85 0.01 260)',
+  // Stronger border for form-field outlines (input, select, checkbox unchecked,
+  // etc.) — needs WCAG 1.4.11 (3:1) against the surface.
+  colorBorderStrong: 'oklch(0.7 0.01 260)',
+  // Border for floating surfaces (popover, tooltip, menu, select listbox, etc.)
+  // — distinct from in-popup separators.
+  colorPopoverBorder: 'oklch(0.78 0.01 260)',
+  // Empty-track color for slider, progress, meter.
+  colorTrack: 'oklch(0.88 0.005 260)',
 
   // Text
   colorText: 'oklch(0.15 0.02 260)',


### PR DESCRIPTION
## Summary

Token-level surgery to resolve P0/P1 items from the dark+light contrast audit. Branched off `main` and stays clear of the in-flight quality pass on `chore/p1-p2-quality-pass` (PR #42) — both can land in either order.

The audit doc that drove this work lives on PR #42's branch at `docs/plans/2026-04-28-a11y-audit-findings.md` (not on `main` yet). The "Theme contrast audit → Proposed token surgery" shortlist there is the source-of-truth checklist below.

## Audit items — resolution status

### Dark mode

P0
- ✅ `switch` unchecked thumb invisible against track — thumb now `colorText`, checked flips to `colorTextInverse`.
- ✅ `menu` itemDestructive AA fail — new `colorDestructiveText` token (dark L=0.78) used here and in submenus.
- ✅ `button outlineDestructive` / `ghostDestructive` AA fail — same `colorDestructiveText` swap.

P1
- ✅ slider/progress/meter empty track invisible — new `colorTrack` token (dark L=0.30, light L=0.88).
- ✅ separators + popup borders dissolve — dark `colorBorder` 0.35→0.42, dark `colorBorderMuted` 0.28→0.36, plus a new `colorPopoverBorder` token for floating surfaces.
- ✅ avatar fallback below AA — fallback initials now `colorText`.
- ✅ scroll-area thumb / `colorIcon` had no dark override — formalized with explicit `colorIcon` (dark L=0.65, light L=0.6).
- ⚠️ dialog/alert-dialog/drawer popups still rely on shadow-only edge — **not addressed in this PR** (popup borders weren't part of the surgery shortlist). Flag for Dave's eye.

P2
- ✅ focus ring contrast — per-theme `colorFocusRing` (light 0.55, dark 0.65) replacing the single 0.7 base.
- ⚠️ placeholder, toast description, tabs inactive chip — borderline items left for visual confirm; deferred to a separate visual-regression sprint.

### Light mode

P0
- ✅ navigation-menu viewportArrow invisible — now `colorPopoverBorder`.
- ✅ menubar root border invisible — now `colorBorder`.
- ⚠️ toast destructive description borderline — left as-is (bg-fill destructive untouched per brief).

P1
- ✅ all floating-surface borders (autocomplete/combobox/select/menu/navigation-menu/popover/preview-card/toast/tooltip) — `colorPopoverBorder` (or `colorBorder` for in-popup separators).
- ✅ form-field 1.4.11 fails (input/field/select/combobox/autocomplete/number-field/checkbox/radio/switch off) — light `colorBorder` 0.85→0.75 + new `colorBorderStrong` (light 0.7) for outlines.
- ✅ in-popup separators invisible — `colorBorder` (now bumped to 0.75).
- ✅ focus ring borderline — light override added.
- ✅ avatar fallback at threshold — `colorText`.
- ✅ tooltip surface = page bg — Linear-style invert (dark tooltip on white, light tooltip on dark via the `colorText`/`colorTextInverse` pair).
- ⚠️ scroll-area thumb borderline — left (P2-ish, no surgery item).

## Tokens added

`colorBorderStrong`, `colorPopoverBorder`, `colorTrack`, `colorDestructiveText`, `colorSuccessText`. `colorIcon` formalized per-theme.

## Tokens retuned

| Token | Light | Dark |
|---|---|---|
| `colorBorder` | 0.85 → 0.75 | 0.35 → 0.42 |
| `colorBorderMuted` | 0.91 → 0.85 | 0.28 → 0.36 |
| `colorFocusRing` | 0.7 → 0.55 | 0.55 → 0.65 |

## Visual judgment calls

- **Tooltip border** dropped to `transparent` rather than adopting `colorPopoverBorder`. The bidirectional surface invert (light-on-dark, dark-on-light) provides edge definition on its own and a popoverBorder treatment doesn't read against the inverted surface. Worth a visual confirm.
- **`Switch` track off-state** uses `colorBorderStrong` for both border and bg (matches form-field strong outlines and gives the unchecked thumb the contrast it needs).
- **`Separator.Root`** standalone bumped to `colorBorder` (not `colorBorderMuted`). It's used in both popup and page contexts; the previous muted value was invisible on white. Bumping universally keeps it readable everywhere.

## Flag for Dave

- **Dialog/alert-dialog/drawer popup borders** remain shadow-only — a P1 audit item that wasn't in the surgery shortlist. Worth opening a follow-up to thread `colorPopoverBorder` through those.
- **Test count** came in at 38 files / 178 tests (brief expected 39/182). All green; the discrepancy looks like a brief-vs-actual drift, not a regression.

## Test plan

- [ ] Verify Vercel preview URL renders correctly in both light and dark modes
- [ ] Visual confirm tooltip invert in both themes (Linear-style)
- [ ] Spot-check switch thumb visibility unchecked + checked, both themes
- [ ] Spot-check form-field outlines (input/select/combobox) on white
- [ ] Spot-check menu/select/popover borders on white and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)