### PR TITLE
chore(cli): end-to-end verification + integration test (P0)

### DIFF
--- a/packages/cli/src/__tests__/integration.test.ts
+++ b/packages/cli/src/__tests__/integration.test.ts
@@ -1,8 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mock @clack/prompts so runAdd() can be tested without TTY / interactive IO
+// ---------------------------------------------------------------------------
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  log: { success: vi.fn(), info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  confirm: vi.fn().mockResolvedValue(true),
+  isCancel: vi.fn().mockReturnValue(false),
+  cancel: vi.fn(),
+}));
 
 const CLI_BIN = resolve(__dirname, '../../dist/index.js');
 
@@ -89,5 +102,62 @@ describe('basex-ui CLI', () => {
     expect(stdout).toContain('[installed]');
     expect(stdout).toContain('Accordion');
     expect(stdout).toContain('[available]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct runAdd() integration — no subprocess, exercises the function itself
+// ---------------------------------------------------------------------------
+describe('runAdd() direct import', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'basex-runcli-test-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('scaffolds button files into src/components/ui/button/', async () => {
+    const { runAdd } = await import('../commands/add.js');
+    await runAdd(['button']);
+
+    const dir = join(tmpDir, 'src/components/ui/button');
+    expect(existsSync(join(dir, 'button.tsx')), 'button.tsx missing').toBe(true);
+    expect(existsSync(join(dir, 'index.ts')), 'index.ts missing').toBe(true);
+    expect(existsSync(join(dir, 'manifest.json')), 'manifest.json missing').toBe(true);
+    expect(existsSync(join(dir, 'button.md')), 'button.md missing').toBe(true);
+  });
+
+  it('button.tsx imports from @base-ui/react/button', async () => {
+    const { runAdd } = await import('../commands/add.js');
+    await runAdd(['button']);
+
+    const tsx = readFileSync(join(tmpDir, 'src/components/ui/button/button.tsx'), 'utf8');
+    expect(tsx).toContain("from '@base-ui/react/button'");
+  });
+
+  it('index.ts re-exports Button from ./button', async () => {
+    const { runAdd } = await import('../commands/add.js');
+    await runAdd(['button']);
+
+    const idx = readFileSync(join(tmpDir, 'src/components/ui/button/index.ts'), 'utf8');
+    expect(idx).toContain("from './button'");
+    expect(idx).toContain('Button');
+  });
+
+  it('manifest.json is valid JSON with correct name', async () => {
+    const { runAdd } = await import('../commands/add.js');
+    await runAdd(['button']);
+
+    const raw = readFileSync(join(tmpDir, 'src/components/ui/button/manifest.json'), 'utf8');
+    const manifest = JSON.parse(raw) as { name: string };
+    expect(manifest.name).toBe('Button');
   });
 });


### PR DESCRIPTION
## Summary

- Smoke tested the packed CLI tarball (`pnpm pack` + install into a fresh Vite react-ts project) — `basex-ui add button` ran cleanly with exit 0, all 4 expected files scaffolded correctly
- Added a `runAdd() direct import` describe block to the existing `packages/cli/src/__tests__/integration.test.ts`, alongside the existing `execSync`-based CLI tests
- Mocks `@clack/prompts` via `vi.mock` so the function runs headless without TTY; uses `process.chdir` + `mkdtemp` for isolation and full cleanup in `afterEach`

## What the integration test covers

1. All 4 expected files scaffold into `src/components/ui/button/` (`button.tsx`, `index.ts`, `manifest.json`, `button.md`)
2. `button.tsx` contains the correct import (`from '@base-ui/react/button'`)
3. `index.ts` re-exports `Button` from `./button`
4. `manifest.json` parses as valid JSON and has `name: "Button"`

## Smoke test result

Passed clean — no fixes required to `add.ts`.

## Verify gates

- `pnpm test:ci` — 39 test files, 222 tests, 0 failures (4 new tests added)
- `pnpm lint` — 0 errors (1 pre-existing warning in `apps/docs/src/App.tsx`, unrelated)
- `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)